### PR TITLE
chore: add repo essentials for customer-facing launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Report a problem with an existing skill or repo tooling
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Not for security issues.** See [SECURITY.md](../../SECURITY.md) and report privately via [GitHub Security Advisories](https://github.com/alpacahq/alpaca-skills/security/advisories/new).
+
+  - type: input
+    id: skill
+    attributes:
+      label: Skill path or name
+      description: e.g. `skills/trading-api/backtest/` or `alpaca-trading-backtest`
+      placeholder: skills/trading-api/backtest/
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: macOS 15, Ubuntu 24.04, etc.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Agent / IDE
+      options:
+        - Cursor
+        - Claude Code
+        - VS Code Copilot
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: cli-version
+    attributes:
+      label: Alpaca CLI version (if relevant)
+      placeholder: Run `alpaca version`
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Optional

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/alpacahq/alpaca-skills/security/advisories/new
+    about: Report security issues privately (do not use public issues)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Propose a new skill or improvement
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed skill or improvement
+    validations:
+      required: true
+
+  - type: dropdown
+    id: product
+    attributes:
+      label: Product area
+      options:
+        - trading-api
+        - broker-api
+    validations:
+      required: true
+
+  - type: dropdown
+    id: cli-mcp
+    attributes:
+      label: Needs CLI or MCP access?
+      options:
+        - Alpaca CLI only
+        - MCP server
+        - Neither / docs only
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+<!-- What changed and why -->
+
+## Type of change
+- [ ] New skill
+- [ ] Improvement to existing skill
+- [ ] Bug fix
+- [ ] Documentation / repo infrastructure
+
+## Checklist
+- [ ] Read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
+- [ ] Skill lives under `skills/trading-api/` or `skills/broker-api/`
+- [ ] Skill `name` follows `alpaca-<product-scope>-<skill-name>` (`trading` or `broker`)
+- [ ] `SKILL.md` has `name` + `description` frontmatter
+- [ ] `reference.md` exists alongside `SKILL.md`
+- [ ] No API keys or secrets committed
+- [ ] Disclosure language included for trading-related outputs (if applicable)
+- [ ] Updated [README.md](../README.md) skills table (if adding or renaming a skill)

--- a/.github/workflows/skill-check.yml
+++ b/.github/workflows/skill-check.yml
@@ -1,0 +1,26 @@
+name: skill-check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-skills:
+    name: Validate skills
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@4239362448deb12227f89fca423e33a2abecdb0 # v5.1.0
+        with:
+          python-version: "3.11"
+
+      - name: Run skill validator
+        run: python3 scripts/validate_skills.py

--- a/.github/workflows/skill-check.yml
+++ b/.github/workflows/skill-check.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@4239362448deb12227f89fca423e33a2abecdb0 # v5.1.0
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: "3.11"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,4 +30,8 @@ Conventions for authoring and maintaining skills in this repository.
 3. Write workflow and guardrails in `SKILL.md`; put formulas, schemas, and CLI reference in `reference.md`.
 4. Open a pull request. A maintainer will review before merge.
 
+## Continuous integration
+
+Pull requests to `main` run `scripts/validate_skills.py` via the `skill-check` GitHub Actions workflow. Fix any reported file and rule before requesting review.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full process.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # Default owner for root docs and unmatched paths
-*                       @idsts2670
+*                       @olavado @sai-g @ggrace01
 
-/skills/trading-api/    @idsts2670
-/skills/broker-api/     @idsts2670
+/skills/trading-api/    @olavado @sai-g @ggrace01
+/skills/broker-api/     @olavado @sai-g @ggrace01
 
 # Repo infrastructure
-/.github/               @idsts2670
-/scripts/               @idsts2670
+/.github/               @olavado @sai-g @ggrace01
+/scripts/               @olavado @sai-g @ggrace01

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,9 @@
-# Trading API skills
+# Default owner for root docs and unmatched paths
+*                       @idsts2670
+
 /skills/trading-api/    @idsts2670
+/skills/broker-api/     @idsts2670
+
+# Repo infrastructure
+/.github/               @idsts2670
+/scripts/               @idsts2670

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,9 @@ Thank you for contributing to Alpaca Skills. This repository is open to improvem
 2. Pick a product folder: `skills/trading-api/` or `skills/broker-api/`.
 3. Choose a `name` following `alpaca-<product-scope>-<skill-name>` (e.g. `alpaca-trading-my-skill`). `<product-scope>` is `trading` or `broker`.
 4. Copy `templates/skill/` as your starting point.
+5. Run `python3 scripts/validate_skills.py` locally before pushing.
+
+For security issues, see [SECURITY.md](SECURITY.md). This project is licensed under the [Apache License 2.0](LICENSE).
 
 ## Skill requirements
 
@@ -38,7 +41,8 @@ Maintainers check for:
 
 1. Fork the repository and create a feature branch.
 2. Make your changes and self-review against [AGENTS.md](AGENTS.md).
-3. Open a PR with a short summary and test plan.
-4. A maintainer will review and merge or request changes.
+3. Use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) when opening a PR.
+4. Ensure `python3 scripts/validate_skills.py` passes (also enforced by the `skill-check` CI workflow).
+5. A maintainer will review and merge or request changes.
 
 Questions? Open a discussion or issue on GitHub.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Alpaca
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,15 @@ Product namespacing uses the folder path (`skills/trading-api/`, `skills/broker-
 - [Alpaca CLI](https://github.com/alpacahq/cli)
 - [Trading API documentation](https://docs.alpaca.markets/)
 - [Alpaca disclosures](https://alpaca.markets/disclosures)
+- [Security policy](SECURITY.md)
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Agent conventions for skill authors are in [AGENTS.md](AGENTS.md).
+
+## License
+
+Licensed under the Apache License 2.0. See [LICENSE](LICENSE).
 
 ## Disclosure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| --- | --- |
+| `main` | Yes |
+
+This repository does not publish semver releases yet. Security fixes land on `main`.
+
+## Reporting a vulnerability
+
+**Do not open public GitHub issues for security vulnerabilities.**
+
+Preferred channel: [GitHub Security Advisories](https://github.com/alpacahq/alpaca-skills/security/advisories/new) (private).
+
+Alternate: email **security@alpaca.markets** with:
+
+- Description of the issue
+- Steps to reproduce
+- Impact assessment (if known)
+
+## Response targets
+
+- Initial acknowledgment: within ~48 hours
+- Status update: within ~7 days
+- Fix timeline: varies by severity
+
+## Scope
+
+In scope:
+
+- Credential handling in skills
+- Malicious skill content
+- Secrets committed in pull requests
+
+Out of scope:
+
+- Trading losses or P&L outcomes from backtest or paper-trading output
+
+## API keys and credentials
+
+Never commit Alpaca API keys, secret keys, or tokens in issues or pull requests. Use environment variables as described in [AGENTS.md](AGENTS.md).

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Validate alpaca-skills layout, frontmatter, and basic secret heuristics."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = ROOT / "skills"
+NAME_PATTERN = re.compile(r"^alpaca-(trading|broker)-[a-z0-9-]+$")
+
+SECRET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "secret-alpaca-key",
+        re.compile(r"ALPACA_SECRET_KEY\s*=\s*[^.\s]{8,}"),
+    ),
+    (
+        "secret-sk-prefix",
+        re.compile(r"sk-[a-zA-Z0-9]{20,}"),
+    ),
+    (
+        "secret-pk-prefix",
+        re.compile(r"PK[A-Z0-9]{18,}"),
+    ),
+]
+
+PLACEHOLDER_MARKERS = (
+    "placeholder",
+    "your-secret",
+    "your_secret",
+    "example",
+    "xxx",
+    "redacted",
+    "<secret",
+    "changeme",
+)
+
+
+class ValidationError(Exception):
+    def __init__(self, rule: str, path: Path, message: str) -> None:
+        self.rule = rule
+        self.path = path
+        self.message = message
+        super().__init__(f"{path}: [{rule}] {message}")
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    block = text[3:end].strip()
+    fields: dict[str, str] = {}
+    current_key: str | None = None
+    for line in block.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith(" ") or line.startswith("\t"):
+            if current_key is not None:
+                fields[current_key] += "\n" + line.strip()
+            continue
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        current_key = key.strip()
+        fields[current_key] = value.strip()
+    return fields
+
+
+def is_skill_dir(path: Path) -> bool:
+    return (path / "SKILL.md").is_file()
+
+
+def find_skill_md_files() -> list[Path]:
+    if not SKILLS_DIR.is_dir():
+        return []
+    return sorted(SKILLS_DIR.rglob("SKILL.md"))
+
+
+def validate_skill_layout(skill_md: Path) -> None:
+    rel = skill_md.relative_to(ROOT)
+    parts = rel.parts
+    if len(parts) != 4 or parts[0] != "skills" or parts[3] != "SKILL.md":
+        raise ValidationError(
+            "skill-layout",
+            skill_md,
+            "SKILL.md must live at skills/<product>/<skill-name>/SKILL.md",
+        )
+
+
+def validate_no_top_level_skills() -> None:
+    top_level = SKILLS_DIR / "SKILL.md"
+    if top_level.is_file():
+        raise ValidationError(
+            "no-top-level-skills",
+            top_level,
+            "SKILL.md must not exist directly under skills/",
+        )
+
+
+def validate_frontmatter(skill_md: Path) -> dict[str, str]:
+    text = skill_md.read_text(encoding="utf-8")
+    fields = parse_frontmatter(text)
+    if "name" not in fields or not fields["name"].strip():
+        raise ValidationError("frontmatter-name", skill_md, "missing name in frontmatter")
+    if "description" not in fields or not fields["description"].strip():
+        raise ValidationError(
+            "frontmatter-description",
+            skill_md,
+            "missing description in frontmatter",
+        )
+    return fields
+
+
+def validate_name(skill_md: Path, name: str) -> None:
+    if not NAME_PATTERN.match(name):
+        raise ValidationError(
+            "name-pattern",
+            skill_md,
+            f"name '{name}' must match alpaca-(trading|broker)-<skill-name>",
+        )
+
+
+def validate_reference(skill_md: Path) -> None:
+    reference = skill_md.parent / "reference.md"
+    if not reference.is_file():
+        raise ValidationError(
+            "reference-missing",
+            skill_md,
+            "reference.md must exist alongside SKILL.md",
+        )
+
+
+def is_placeholder_context(text: str, match_start: int) -> bool:
+    window_start = max(0, match_start - 80)
+    window_end = min(len(text), match_start + 80)
+    window = text[window_start:window_end].lower()
+    return any(marker in window for marker in PLACEHOLDER_MARKERS)
+
+
+def scan_secrets(path: Path) -> None:
+    rel = path.relative_to(ROOT)
+    rel_str = rel.as_posix()
+    if rel_str.startswith("templates/"):
+        return
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for rule, pattern in SECRET_PATTERNS:
+        for match in pattern.finditer(text):
+            if is_placeholder_context(text, match.start()):
+                continue
+            raise ValidationError(
+                rule,
+                path,
+                f"suspicious secret-like content: {match.group()[:24]}...",
+            )
+
+
+def scan_secret_directories() -> None:
+    for subdir in ("skills", "scripts"):
+        base = ROOT / subdir
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*")):
+            if not path.is_file():
+                continue
+            if path.suffix in {".pyc"}:
+                continue
+            scan_secrets(path)
+
+
+def validate_skills() -> list[str]:
+    errors: list[str] = []
+    validate_no_top_level_skills()
+
+    skill_files = find_skill_md_files()
+    for skill_md in skill_files:
+        try:
+            validate_skill_layout(skill_md)
+            fields = validate_frontmatter(skill_md)
+            validate_name(skill_md, fields["name"])
+            validate_reference(skill_md)
+        except ValidationError as exc:
+            errors.append(str(exc))
+
+    try:
+        scan_secret_directories()
+    except ValidationError as exc:
+        errors.append(str(exc))
+
+    return errors
+
+
+def main() -> int:
+    errors = validate_skills()
+    if errors:
+        print("validate_skills.py failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    print("validate_skills.py: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds Apache-2.0 LICENSE, SECURITY.md, expanded CODEOWNERS, GitHub PR/issue templates, and skill validation CI (`scripts/validate_skills.py` + `skill-check` workflow).

## Test plan
- [x] `python3 scripts/validate_skills.py` passes locally on this branch
- [ ] `skill-check` workflow green on PR
- [ ] Issue forms render (bug + feature); blank issues disabled; security contact link works
- [ ] PR template auto-fills on new PR
- [ ] LICENSE and SECURITY visible on repo home / Security tab
- [x] Repo description/topics verified via `gh repo view` (no change needed)

## Metadata
- [x] Verified repo description/topics (no change)

Made with [Cursor](https://cursor.com)