### PR TITLE
Add talib and Remove Second Person Voice

### DIFF
--- a/skills/trading-api/backtest/SKILL.md
+++ b/skills/trading-api/backtest/SKILL.md
@@ -9,185 +9,70 @@ description: >
 
 # Trading API Backtesting
 
-Use this skill when you want your AI agent to run a specific historical backtest with the Alpaca CLI and local workspace code. This version is optimized for run-specific execution: your agent writes the minimum readable code needed for the confirmed strategy, stores the exact artifacts, and reports the results back to you.
-
-This skill is written for you, the person invoking it through your AI agent. **You** means the trader, developer, researcher, or operator asking your agent to run the backtest. Your agent should address you directly, restate assumptions clearly, and make every interpretation choice visible.
-
 ```text
 strategy idea -> formalized rules -> confirmed assumptions -> CLI data fetch -> local script -> artifacts -> report
 ```
 
-It is not a promise that a strategy will work in live markets. It is a reproducible research workflow.
+This is a reproducible research workflow, not a guarantee of live-market performance.
 
 ## Required disclosures
 
-Every report, `notes.md`, `report.md`, notebook, dashboard, or exported result should include:
+Every report, `notes.md`, `report.md`, notebook, or exported result must include:
 
 > **Important disclosure**  
-> This backtest is a hypothetical historical simulation and does not represent actual trading performance. Backtested results do not guarantee future results. Results depend on market-data quality, data feed selection, corporate-action handling, fees, slippage, liquidity, taxes, execution assumptions, and implementation details. This material is for research and educational purposes only and is not investment advice, a recommendation, an offer, or a solicitation to buy or sell securities, options, cryptocurrencies, or any other financial product. All investments involve risk and may lose value. Review Alpaca's disclosures and agreements at [alpaca.markets/disclosures](https://alpaca.markets/disclosures).
+> This backtest is a hypothetical historical simulation and does not represent actual trading performance. Backtested results do not guarantee future results. Results depend on market-data quality, data feed selection, corporate-action handling, fees, slippage, liquidity, taxes, execution assumptions, and implementation details. This material is for research and educational purposes only and is not investment advice, a recommendation, an offer, or a solicitation to buy or sell securities, options, cryptocurrencies, or any other financial product. All investments involve risk and may lose value. Review Alpaca's disclosures at [alpaca.markets/disclosures](https://alpaca.markets/disclosures).
 
-When paper trading appears in the workflow, add:
+When paper trading appears, add:
 
 > Paper trading is a simulated environment. It does not involve real money or actual securities transactions. Paper results may differ from live trading because of fill assumptions, market impact, liquidity, latency, data differences, order handling, fees, and other market conditions.
 
-When the backtest models Alpaca securities trading-activity fees, `notes.md`, `summary.json`, and `report.md` should link to the Alpaca Brokerage Fee Schedule PDF:
-
-```text
-https://files.alpaca.markets/disclosures/library/BrokFeeSched.pdf
-```
-
-Record the PDF revision date, extraction timestamp, modeled fee categories, and any fee items intentionally excluded.
+When modeling Alpaca securities trading-activity fees, link to `https://files.alpaca.markets/disclosures/library/BrokFeeSched.pdf` and record the PDF revision date, extraction timestamp, and modeled/excluded fee categories in `fee_source.json`.
 
 ## CLI prerequisites
 
-### Alpaca CLI
-
-Your agent should use the Alpaca CLI for market-data access.
-
-Check whether it is installed:
-
-```bash
-alpaca version
-```
-
-Install with Go when needed:
+Install the Alpaca CLI:
 
 ```bash
 go install github.com/alpacahq/cli/cmd/alpaca@latest
+# or: brew install alpacahq/tap/cli
 ```
 
-On macOS or Linux with Homebrew:
-
-```bash
-brew install alpacahq/tap/cli
-```
-
-Make sure the binary directory is on `PATH`, commonly `~/go/bin` for Go installs.
-
-### Local execution permissions
-
-Alpaca CLI commands should run in your local workspace where your Alpaca profile, environment variables, network access, and saved artifacts are available. Some agent runtimes express this as:
-
-```text
-required_permissions: ["all"]
-```
-
-Use the equivalent permission model in your agent environment so the CLI can access local auth/config and write run artifacts.
-
-### Connectivity and authentication check
-
-Before any backtest run, verify the CLI and credentials:
+Authenticate and verify before every run:
 
 ```bash
 alpaca doctor
+# if auth fails: alpaca profile login --api-key
+# or set ALPACA_API_KEY and ALPACA_SECRET_KEY environment variables
 ```
 
-If authentication fails, your agent should stop the run and show you the available login/help command:
+Never print or commit the secret key. Use `--quiet` for machine-readable output. Prefer current `--help` and `--schema` output over stale examples in this document, as the CLI evolves.
 
-```bash
-alpaca profile login --help
-```
-
-For interactive paper setup:
-
-```bash
-alpaca profile login
-```
-
-For API-key setup:
-
-```bash
-alpaca profile login --api-key
-```
-
-For automation, environment variables are preferred because secrets do not need to be written into generated code:
-
-```bash
-export ALPACA_API_KEY=PK...
-export ALPACA_SECRET_KEY=...
-export ALPACA_QUIET=1
-```
-
-Your agent should never print your secret key, commit it to files, include it in reports, or pass it in a way that exposes it to shell history.
-
-### Machine-readable output
-
-Use `--quiet` for commands whose output will be parsed by code:
-
-```bash
-alpaca account get --quiet
-alpaca data bars --symbol SPY --start 2024-01-01 --end 2024-12-31 --timeframe 1Day --quiet
-```
-
-Use installed CLI help and schemas as the source of truth for flags and response fields:
-
-```bash
-alpaca --help-all
-alpaca data bars --help
-alpaca data bars --schema
-alpaca data quotes --schema
-```
-
-Because the CLI is generated from API specifications and may evolve, your agent should prefer current `--help`, `--schema`, and `alpaca doctor` output over stale examples.
+See [reference.md](reference.md) for full CLI data-fetch commands, pagination, and schema flags.
 
 ## Required workflow
 
-Your agent should follow this workflow:
-
-1. Gather required inputs: start date, end date, strategy concept or strategy file.
-2. Gather or infer the rest: asset class, symbols or universe, timeframe, initial cash, position sizing, feed, adjustment mode, execution assumptions, benchmark.
-3. Work through [run considerations](#run-considerations-checklist): order simulation, indicators, dividends, splits, fees, slippage, spread, market hours, calendar handling, and validation.
-4. Translate your freeform idea into precise mathematical rules.
-5. Present the formalized interpretation to you before writing code unless your request was already mathematically precise.
+1. Gather required inputs: start date, end date, strategy concept or file.
+2. Infer the rest: asset class, symbols, timeframe, initial cash, position sizing, feed, adjustment, execution assumptions, benchmark.
+3. Resolve [run considerations](#run-considerations-checklist): order simulation, indicators, dividends, splits, fees, slippage, calendar, look-ahead bias.
+4. Translate freeform ideas into precise mathematical rules.
+5. Present the formalized interpretation before writing code unless the request was already precise.
 6. Check the workspace for reusable data, prior runs, and existing utilities.
 7. Create a self-contained run folder.
 8. Write `notes.md`, `strategy_spec.json`, `config.json`, and a readable run-specific script.
-9. Fetch historical data through the Alpaca CLI, save raw CLI outputs, filter to the chosen market hours, and compute data fingerprints.
-10. Run the local simulation.
-11. Write artifacts.
-12. Return the Teaching Five, first/last trade, assumptions, caveats, data fingerprint, and artifact paths.
+9. Fetch historical data via the CLI, save raw outputs, filter to market hours, compute data fingerprints.
+10. Run the local simulation, write artifacts, and return the [Teaching Five](#in-chat-response-standard).
 
 ## Workspace awareness
 
-Before generating new code or fetching data, your agent should inspect the workspace.
+Before generating new code or fetching data, inspect the workspace.
 
-### Data reuse
+**Data reuse**: reuse raw/normalized files only when all fingerprint fields match — symbol, feed, adjustment, timeframe, calendar filter, and date range. If fingerprints differ, treat the data as different.
 
-Look for prior raw data files or cached normalized data that match:
+**Run lineage**: if this run is a variant of a prior run, `notes.md` must state what changed (e.g., changed RSI threshold, extended date range, changed fill model).
 
-```text
-symbol
-asset class
-feed
-adjustment mode
-timeframe
-start/end range
-calendar filter
-regular-hours or extended-hours setting
-```
-
-Reuse data only when the data fingerprint matches. If fingerprints differ, your agent should treat the runs as using different input data.
-
-### Run lineage
-
-If this run is a variant of a prior run, `notes.md` should say what changed:
-
-```text
-changed RSI threshold from 30/70 to 25/75
-changed fill model from next_open bar proxy to quote-aware fill
-changed slippage from 5 bps to 10 bps
-extended date range from 2020-2024 to 2018-2025
-```
-
-### Existing code
-
-If the workspace already has a backtest engine or shared utility that matches the strategy requirements, your agent may reuse it. Otherwise, the default is a single readable `run.py` in the run folder.
+**Existing code**: reuse a workspace backtest engine only when it matches strategy requirements. Otherwise default to a single `run.py`.
 
 ## Run folder and artifact contract
-
-Artifact paths in this skill use `raw/` and `normalized/` as canonical names.
-
-Every run should create a folder like:
 
 ```text
 runs/YYYY-MM-DD_symbol_strategy_timeframe/
@@ -195,16 +80,14 @@ runs/YYYY-MM-DD_symbol_strategy_timeframe/
   strategy_spec.json
   config.json
   run.py
-  requirements.txt or pyproject.toml when needed
+  requirements.txt or pyproject.toml (when needed)
   raw/
     bars_SYMBOL.json
-    quotes_SYMBOL.json
-    trades_SYMBOL.json
+    quotes_SYMBOL.json (when fetched)
     calendar.json
-    corporate_actions.json
+    corporate_actions.json (when fetched)
   normalized/
     bars_SYMBOL.csv
-    quotes_SYMBOL.csv
   summary.json
   report.md
   trades.csv
@@ -216,44 +99,31 @@ runs/YYYY-MM-DD_symbol_strategy_timeframe/
   fee_source.json
 ```
 
-### `notes.md`
+`notes.md` must include: original request, confirmed interpretation, every inferred assumption, indicator definitions, fill model, fee model, feed and adjustment mode, dividend/split treatment, benchmark definitions, calendar handling, warnings, caveats, and disclosure links.
 
-`notes.md` should include your original request, confirmed strategy interpretation, every inferred/defaulted assumption, indicator definitions, fill model, fee model, data feed and adjustment mode, dividend and split treatment, benchmark definitions, calendar and market-hours handling, warnings and caveats, and Alpaca disclosure and fee schedule links.
-
-### Other artifacts
-
-See [reference.md](reference.md) for `summary.json`, `strategy_spec.json`, `data_fingerprint.json`, and `fee_source.json` schemas.
+See [reference.md](reference.md) for artifact JSON schemas.
 
 ## Code generation rules
 
-For run-specific CLI backtests, your agent should generate a script, not a reusable framework. A single-file `run.py` is the default.
-
-Use readable code:
+Generate a single-file `run.py` by default. Use readable code:
 
 ```python
 fill_price = bar_open * (1 + friction_pct)
 ```
 
-instead of compressed expressions that make the artifact hard to audit.
+Generated code must:
+- read raw/normalized files from the run folder
+- implement the confirmed strategy and indicator definitions exactly — see [talib.md](talib.md)
+- keep signal timing separate from fill timing
+- compute fees, slippage, spread, and settlement per confirmed assumptions
+- produce all required artifacts with deterministic sorting and timezone handling
+- avoid hidden network calls after data fetch
 
-The generated code should:
-
-- read raw or normalized files from the run folder;
-- implement the confirmed strategy exactly;
-- implement the chosen indicator definitions exactly (see [Indicator formulas](reference.md#indicator-formulas));
-- keep signal timing separate from fill timing;
-- compute fees, slippage, spread, and settlement according to the confirmed assumptions;
-- produce all required artifacts;
-- include deterministic sorting and timezone handling;
-- avoid hidden network calls after data fetch unless explicitly documented.
-
-Use Python 3 by default. Prefer the standard library plus pandas/numpy when available. Add dependencies only when they materially improve correctness or readability.
+Use Python 3. Prefer standard library + pandas/numpy. When strategy needs technical indicators, prefer [talib](talib.md) for correctness and conciseness. Add dependencies only when they materially improve correctness or readability.
 
 ## Strategy translation
 
-Your agent should formalize your idea before code generation.
-
-Every rule should specify: data field, trigger, inclusive/exclusive bounds, indicator variant and parameters, warmup behavior, position sizing and rounding, cash handling, order type, fill model, and benchmark.
+Before writing code, confirm every rule specifies: data field, trigger, inclusive/exclusive bounds, indicator variant and parameters, warmup behavior, position sizing, order type, fill model, and benchmark.
 
 Example confirmation:
 
@@ -263,29 +133,24 @@ I interpreted your strategy as:
 - Timeframe: 1Day
 - Data: Alpaca CLI bars, feed=sip, adjustment=split
 - Indicator: SMA(50) and SMA(200), simple arithmetic mean of completed daily closes
-- Entry: fast SMA crosses above slow SMA
-- Exit: fast SMA crosses below slow SMA
-- Signal timing: completed bar close
-- Fill timing: next trading day's open
-- Fill model: next_open bar proxy with 5 bps slippage unless quotes are available
-- Sizing: invest 100% of available cash, fractional shares allowed when supported
+- Entry: fast SMA crosses above slow SMA (next-bar open)
+- Fill model: next_open bar proxy with 5 bps slippage
+- Sizing: 100% of available cash, whole shares
 - Benchmark: SPY buy-and-hold with same assumptions
 ```
 
-After confirmation, code should match the confirmed interpretation.
-
 ## Fill models
 
-Use these model names in confirmations and `notes.md`. Implementation detail is in [Fill model rules](reference.md#fill-model-rules).
+Use these model names in confirmations and `notes.md`. Full implementation rules in [reference.md — Fill model rules](reference.md#fill-model-rules).
 
-- **`next_open`** (default): signal on bar T close; fill on bar T+1 open or quote at T+1 open timestamp.
-- **`time_based`**: fill at a confirmed time of day; quote bid/ask when available.
-- **`same_bar`**: only when explicitly requested; document look-ahead risk in `notes.md` and the report.
-- **Limit and stop orders**: OHLC-bar eligibility rules apply; use conservative intrabar conflict policy when stop and target both touch the same bar.
+- **`next_open`** (default): signal on bar T close; fill on bar T+1 open.
+- **`time_based`**: fill at a confirmed time of day; use quote bid/ask when available.
+- **`same_bar`**: only when explicitly requested; document look-ahead risk in `notes.md`.
+- **Limit/stop orders**: OHLC-bar eligibility rules apply; conservative intrabar conflict policy when stop and target both touch the same bar.
 
 ## Report format
 
-`report.md` should lead with **Performance vs Benchmarks**:
+`report.md` must lead with **Performance vs Benchmarks**:
 
 ```markdown
 | | Total Return | Ann. Return | Max Drawdown | Sharpe | Final Equity |
@@ -294,128 +159,60 @@ Use these model names in confirmations and `notes.md`. Implementation detail is 
 | Benchmark | ...% | ...% | ...% | ... | $... |
 ```
 
-After the table, include strategy configuration, symbols/timeframe/feed/adjustment, fill model and friction, first and last trade, detailed metrics, benchmark explanation, assumptions, data fingerprint, caveats, and the disclosure block.
-
-Metric definitions are in [reference.md](reference.md#metric-formulas).
+Follow with: strategy configuration, symbols/timeframe/feed/adjustment, fill model and friction, first/last trade, detailed metrics, benchmark explanation, assumptions, data fingerprint, caveats, and the disclosure block. Metric definitions in [reference.md — Metric formulas](reference.md#metric-formulas).
 
 ## In-chat response standard
 
 Lead with the **Teaching Five**:
 
-1. total return versus benchmark;
-2. max drawdown;
-3. number of trades;
-4. win rate;
-5. Sharpe ratio versus benchmark.
+1. Total return versus benchmark
+2. Max drawdown
+3. Number of trades
+4. Win rate
+5. Sharpe ratio versus benchmark
 
-Then include: annualized return, profit factor, fees paid, first trade, last trade, assumptions made, data fingerprint summary, artifact paths, and most important caveats.
+Then include: annualized return, profit factor, fees paid, first/last trade, assumptions made, data fingerprint summary, artifact paths, and most important caveats.
 
-If no trades occurred, say that directly and explain whether this was due to warmup, no signal, insufficient cash, missing data, or calendar filtering.
+If no trades occurred, explain directly whether caused by warmup, no signal, insufficient cash, missing data, or calendar filtering.
 
 ## Run considerations checklist
 
-Your agent should resolve each item before running:
+Resolve each item before running:
 
-- order simulation and fill timing;
-- quote-aware versus bar-proxy fills;
-- dividend handling;
-- split and reverse-split handling;
-- execution friction;
-- PDF-derived trading-activity fees;
-- market hours and extended-hours inclusion;
-- calendar-based decisions;
-- benchmark choice;
-- look-ahead bias;
-- survivorship bias;
-- out-of-sample or walk-forward validation for parameter tuning;
-- overfitting risk for repeated variants.
+- order simulation and fill timing
+- quote-aware versus bar-proxy fills
+- dividend and split/reverse-split handling
+- execution friction (spread + slippage)
+- PDF-derived trading-activity fees
+- market hours and extended-hours inclusion
+- calendar-based decisions
+- benchmark choice
+- look-ahead bias
+- survivorship bias
+- out-of-sample or walk-forward validation for parameter tuning
+- overfitting risk for repeated variants
 
-For order simulation, dividends, splits, fees, calendar, and benchmarks, document choices in `notes.md` when not specified by you.
+Document all choices not explicitly specified in `notes.md`.
 
 ## Safety and quality guardrails
 
-Your agent must avoid:
+Never:
 
-- using future data in signal generation;
-- using same-bar decision and fill without a documented `same_bar` model and warning;
-- hiding execution assumptions;
-- mixing adjusted bars with separate split adjustments;
-- pretending vague rules were fully specified;
-- discarding generated code after the run;
-- including extended-hours bars unless you requested them;
-- silently substituting indicator variants;
-- treating open, close, high, low, VWAP, and quote-derived prices as interchangeable fill proxies;
-- computing Sharpe from per-bar returns when the report says daily Sharpe;
-- using population standard deviation for Sharpe when sample standard deviation (N-1) is required;
-- submitting live orders as part of a historical backtest;
-- claiming support for unsupported products — options require explicit contract selection and fill logic;
-- bypassing the Alpaca CLI by switching to direct HTTP calls;
-- running Alpaca CLI commands in a sandbox without local auth and filesystem access;
-- implementing fill logic that deviates from [Fill model rules](reference.md#fill-model-rules) without documenting the deviation in `notes.md`;
-- using `close` vs `high` vs `low` interchangeably for signal triggers;
-- silently choosing between crossover and threshold signal logic;
-- generating a multi-module engine when a single-file script will do.
-
-## Optional paper forward-validation handoff
-
-After a historical backtest, your agent may prepare a paper forward-validation package if you request it:
-
-```text
-paper_config.json
-strategy_runtime.py
-risk_limits.json
-alpaca_order_adapter.py
-reconciliation_plan.md
-```
-
-This is separate from the historical backtest. It should use explicit risk limits, client order IDs for automation, and reconciliation of expected versus actual paper fills.
-
-## Troubleshooting
-
-```text
-command not found: alpaca
-  Check PATH and Go install location, commonly ~/go/bin.
-
-alpaca doctor reports auth failure
-  Re-run alpaca profile login or set ALPACA_API_KEY and ALPACA_SECRET_KEY.
-
-CLI output includes non-data text
-  Use --quiet or set ALPACA_QUIET=1.
-
-Parsed fields changed
-  Run <command> --schema and update the parser for the current CLI response.
-
-Rate limited
-  Respect Retry-After, reduce request frequency, and use cached data where fingerprints match.
-
-Pagination missing data
-  Check next_page_token and fetch all pages.
-```
+- use future data in signal generation
+- use `same_bar` model without documenting look-ahead risk
+- hide execution assumptions
+- mix adjusted bars with separate split adjustments
+- pretend vague rules were fully specified
+- include extended-hours bars unless explicitly requested
+- silently substitute indicator variants or price fields (`open`/`close`/`high`/`low`/VWAP are not interchangeable)
+- compute Sharpe from per-bar returns when daily Sharpe is reported
+- use population std dev for Sharpe (use N-1)
+- submit live orders as part of a historical backtest
+- bypass the Alpaca CLI with direct HTTP calls
+- run CLI commands in a sandbox without local auth and filesystem access
+- generate a multi-module engine when a single-file script will do
 
 ## Related references
 
-Useful commands:
-
-```bash
-alpaca version
-alpaca update --check --quiet
-alpaca doctor
-alpaca --help-all
-alpaca data bars --help
-alpaca data bars --schema
-alpaca data quotes --schema
-alpaca calendar --help
-```
-
-Disclosure links:
-
-```text
-https://alpaca.markets/disclosures
-https://files.alpaca.markets/disclosures/library/BrokFeeSched.pdf
-```
-
-CLI data acquisition, indicator formulas, fee model, metrics, benchmarks, and JSON schemas: [reference.md](reference.md).
-
-## Related files
-
-- [reference.md](reference.md)
+- [reference.md](reference.md) — CLI data acquisition, indicator formulas, fill model rules, metric formulas, benchmarks, artifact schemas
+- [talib.md](talib.md) — using TA-Lib for technical indicators in backtest scripts

--- a/skills/trading-api/backtest/reference.md
+++ b/skills/trading-api/backtest/reference.md
@@ -1,6 +1,5 @@
 # Backtest Reference
 
-Companion to `SKILL.md`. Read the workflow and guardrails there first.
 
 ## Supported asset classes
 
@@ -165,43 +164,7 @@ alpaca data <cmd> --help
 
 ## Indicator formulas
 
-These are canonical implementations. Generated code must follow these exactly.
-
-### SMA
-
-Simple arithmetic mean of the last `n` completed closes (or the specified field). No smoothing.
-
-### EMA
-
-1. Multiplier `k = 2 / (n + 1)`.
-2. Seed: first EMA = SMA of the first `n` values.
-3. Subsequent: `EMA = close * k + prev_EMA * (1 - k)`.
-
-### RSI — Wilder's smoothed
-
-1. Seed: first `avg_gain` and `avg_loss` as simple averages over the initial `period` bars.
-2. Subsequent: `avg_gain = (prev_avg_gain * (period - 1) + current_gain) / period` and `avg_loss = (prev_avg_loss * (period - 1) + current_loss) / period`.
-3. `RS = avg_gain / avg_loss`. If `avg_loss == 0`, RSI = 100.
-4. `RSI = 100 - 100 / (1 + RS)`.
-
-Do not use `sum(gains[-period:]) / period` (SMA RSI).
-
-### ATR — Wilder's smoothed
-
-1. True Range: `TR = max(high - low, |high - prev_close|, |low - prev_close|)`.
-2. Seed: first ATR = simple average of the first `period` true ranges.
-3. Subsequent: `ATR = (prev_ATR * (period - 1) + current_TR) / period`.
-
-Do not use `sum(true_ranges[-period:]) / period` (SMA ATR).
-
-### Bollinger Bands
-
-1. Middle band = SMA of `close` over `period`.
-2. Standard deviation = **population** std dev (divide by `N`, not `N-1`).
-3. Upper band = middle + `num_std * std_dev`.
-4. Lower band = middle - `num_std * std_dev`.
-
-The code must not silently substitute one indicator variant for another.
+See [talib.md](talib.md) for canonical indicator implementations and usage. Use talib by default; fall back to manual implementations only when the environment cannot install the TA-Lib C library or the strategy requires a non-standard variant.
 
 ## Fill model rules
 

--- a/skills/trading-api/backtest/talib.md
+++ b/skills/trading-api/backtest/talib.md
@@ -18,12 +18,6 @@ pip install TA-Lib
 python -c "import talib; print(talib.__version__)"
 ```
 
-Add to `requirements.txt`:
-
-```text
-TA-Lib>=0.4.28
-```
-
 If the C library is unavailable in the target environment, prompt the user and ask how to proceed.
 
 ## Input format

--- a/skills/trading-api/backtest/talib.md
+++ b/skills/trading-api/backtest/talib.md
@@ -1,0 +1,147 @@
+# Using TA-Lib in Backtest Scripts
+
+TA-Lib (Technical Analysis Library) provides fast, correct implementations of common technical indicators. Prefer it over manual implementations when writing `run.py` — it reduces code length and eliminates common mistakes like using SMA-seeded RSI instead of Wilder's smoothing.
+
+## Installation
+
+```bash
+# Install the C library first, then the Python wrapper
+# macOS
+brew install ta-lib
+pip install TA-Lib
+
+# Ubuntu / Debian
+sudo apt-get install libta-lib-dev
+pip install TA-Lib
+
+# Verify
+python -c "import talib; print(talib.__version__)"
+```
+
+Add to `requirements.txt`:
+
+```text
+TA-Lib>=0.4.28
+```
+
+If the C library is unavailable in the target environment, prompt the user and ask how to proceed.
+
+## Input format
+
+TA-Lib functions expect NumPy arrays of `float64`. When working from a pandas DataFrame, pass the underlying array:
+
+```python
+import talib
+import numpy as np
+
+close = df["c"].values.astype(float)
+high  = df["h"].values.astype(float)
+low   = df["l"].values.astype(float)
+open_ = df["o"].values.astype(float)
+```
+
+All inputs must be the same length. TA-Lib handles the warmup period internally and returns `NaN` for leading values that cannot be computed.
+
+## Key functions
+
+### SMA
+
+```python
+sma50  = talib.SMA(close, timeperiod=50)
+sma200 = talib.SMA(close, timeperiod=200)
+```
+
+### EMA
+
+```python
+ema12 = talib.EMA(close, timeperiod=12)
+ema26 = talib.EMA(close, timeperiod=26)
+```
+
+
+### RSI (Wilder's smoothed)
+
+```python
+rsi14 = talib.RSI(close, timeperiod=14)
+```
+
+### MACD
+
+```python
+macd, signal, hist = talib.MACD(close, fastperiod=12, slowperiod=26, signalperiod=9)
+```
+
+`macd` = EMA(fast) − EMA(slow). `signal` = EMA of macd. `hist` = macd − signal.
+
+### ATR (Wilder's smoothed)
+
+```python
+atr14 = talib.ATR(high, low, close, timeperiod=14)
+```
+
+### Bollinger Bands
+
+```python
+upper, middle, lower = talib.BBANDS(close, timeperiod=20, nbdevup=2, nbdevdn=2, matype=0)
+```
+
+`matype=0` is SMA. TA-Lib uses **population** std dev (divide by N), matching [reference.md — Bollinger Bands](reference.md#bollinger-bands).
+
+### Stochastic
+
+```python
+slowk, slowd = talib.STOCH(high, low, close,
+    fastk_period=14, slowk_period=3, slowk_matype=0,
+    slowd_period=3, slowd_matype=0)
+```
+
+### ADX
+
+```python
+adx14 = talib.ADX(high, low, close, timeperiod=14)
+```
+
+## Attaching results to a DataFrame
+
+```python
+df["sma50"]  = talib.SMA(close, timeperiod=50)
+df["sma200"] = talib.SMA(close, timeperiod=200)
+df["rsi14"]  = talib.RSI(close, timeperiod=14)
+
+upper, middle, lower = talib.BBANDS(close, timeperiod=20, nbdevup=2, nbdevdn=2)
+df["bb_upper"]  = upper
+df["bb_middle"] = middle
+df["bb_lower"]  = lower
+```
+
+## Warmup handling
+
+Never generate signals on bars where indicator values are `NaN`. Drop or mask the warmup window:
+
+```python
+warmup = 200  # length of longest indicator period
+df = df.iloc[warmup:].copy()
+```
+
+Warmup bars should still appear in the equity curve as flat (fully-in-cash) equity.
+
+## Example: SMA crossover with talib
+
+```python
+import talib
+import numpy as np
+import pandas as pd
+
+df = pd.read_csv("normalized/bars_SPY.csv", parse_dates=["t"])
+close = df["c"].values.astype(float)
+
+df["sma50"]  = talib.SMA(close, timeperiod=50)
+df["sma200"] = talib.SMA(close, timeperiod=200)
+
+# Drop warmup rows
+df = df.dropna(subset=["sma50", "sma200"]).reset_index(drop=True)
+
+# Crossover signals (next-open fill)
+df["cross_up"]   = (df["sma50"] > df["sma200"]) & (df["sma50"].shift(1) <= df["sma200"].shift(1))
+df["cross_down"] = (df["sma50"] < df["sma200"]) & (df["sma50"].shift(1) >= df["sma200"].shift(1))
+```


### PR DESCRIPTION
## Summary
The current implementation of the backtest skill calculates technical indicators manually. This PR resolves this issue by updating the skill and references file to point to a new `talib.md` file with the purpose of providing context to agents of how talib works. At this time I also decided to cut the skill down and remove the second person tone. Skills should be ~200 lines long. This PR replaces "your agent should..." with "do this". The shift towards talib and these other improvements will make the skills in this repository more maintainable and affordable to use.
Note: AI was used to help with these changes
## Type of change
- [ ] New skill
- [x] Improvement to existing skill
- [ ] Bug fix
- [ ] Documentation / repo infrastructure

## Checklist
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] Skill lives under `skills/trading-api/` or `skills/broker-api/`
- [x] Skill `name` follows `alpaca-<product-scope>-<skill-name>` (`trading` or `broker`)
- [x] `SKILL.md` has `name` + `description` frontmatter
- [x] `reference.md` exists alongside `SKILL.md`
- [x] No API keys or secrets committed
- [x] Disclosure language included for trading-related outputs (if applicable)
- [x] Updated [README.md](../README.md) skills table (if adding or renaming a skill)
