### PR TITLE
chore: document Skills CLI installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,40 @@ Skills provide shared instructions, guardrails, and reporting standards so agent
 
 ## Install
 
-Point your agent at a skill directory, or copy it into your agent's skills folder.
+### Recommended: Skills CLI
+
+Use the Skills CLI to install from this GitHub repository:
+
+```bash
+npx skills add alpacahq/alpaca-skills --list
+npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest
+```
+
+Agent-specific global installs:
+
+```bash
+# Cursor
+npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest -g -a cursor -y
+
+# Claude Code
+npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest -g -a claude-code -y
+
+# Codex
+npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest -g -a codex -y
+```
+
+For Claude Code, keep `-a claude-code` in the command. Without an explicit agent target, `npx skills` can install into `.agents/skills/`, which Claude Code does not load directly unless `.claude/` already exists and receives a symlink.
+
+For local development from a checkout:
+
+```bash
+npx skills add . --list
+npx skills add . --skill alpaca-trading-backtest
+```
+
+### Manual install
+
+For agents that do not support the Skills CLI, point your agent at a skill directory, or copy/symlink it into your agent's skills folder.
 
 | Agent | Typical path |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -23,31 +23,17 @@ Skills provide shared instructions, guardrails, and reporting standards so agent
 Use the Skills CLI to install from this GitHub repository:
 
 ```bash
+# Interactive install
+npx skills add alpacahq/alpaca-skills
+
+# Preview available skills
 npx skills add alpacahq/alpaca-skills --list
+
+# Install one specific skill
 npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest
 ```
 
-Agent-specific global installs:
-
-```bash
-# Cursor
-npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest -g -a cursor -y
-
-# Claude Code
-npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest -g -a claude-code -y
-
-# Codex
-npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest -g -a codex -y
-```
-
-For Claude Code, keep `-a claude-code` in the command. Without an explicit agent target, `npx skills` can install into `.agents/skills/`, which Claude Code does not load directly unless `.claude/` already exists and receives a symlink.
-
-For local development from a checkout:
-
-```bash
-npx skills add . --list
-npx skills add . --skill alpaca-trading-backtest
-```
+Swap in any skill name from the table below.
 
 ### Manual install
 


### PR DESCRIPTION
## Summary
- Add `npx skills` as the recommended installation path for Alpaca skills
- Keep the existing manual copy/symlink workflow as a fallback for unsupported agents
- Add agent-specific install examples for Cursor, Claude Code, and Codex, including the Claude Code `.claude/` caveat

## Type of change
- [ ] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [x] Documentation / repo infrastructure

## Checklist
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] Skill lives under `skills/trading-api/` or `skills/broker-api/`
- [x] Skill `name` follows `alpaca-<product-scope>-<skill-name>` (`trading` or `broker`)
- [x] `SKILL.md` has `name` + `description` frontmatter
- [x] `reference.md` exists alongside `SKILL.md`
- [x] No API keys or secrets committed
- [x] Disclosure language included for trading-related outputs (if applicable)
- [ ] Updated [README.md](../README.md) skills table (if adding or renaming a skill)

## Test plan
- [x] `python3 scripts/validate_skills.py`
- [x] `npx skills add . --list`