### PR TITLE
feat: add broker skills and npx skills directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,40 @@ Skills provide shared instructions, guardrails, and reporting standards so agent
 
 ## Install
 
-Point your agent at a skill directory, or copy it into your agent's skills folder.
+### Recommended: Skills CLI
+
+Use the Skills CLI to install from this GitHub repository:
+
+```bash
+npx skills add alpacahq/alpaca-skills --list
+npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest
+```
+
+Agent-specific global installs:
+
+```bash
+# Cursor
+npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest -g -a cursor -y
+
+# Claude Code
+npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest -g -a claude-code -y
+
+# Codex
+npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest -g -a codex -y
+```
+
+For Claude Code, keep `-a claude-code` in the command. Without an explicit agent target, `npx skills` can install into `.agents/skills/`, which Claude Code does not load directly unless `.claude/` already exists and receives a symlink.
+
+For local development from a checkout:
+
+```bash
+npx skills add . --list
+npx skills add . --skill alpaca-trading-backtest
+```
+
+### Manual install
+
+For agents that do not support the Skills CLI, point your agent at a skill directory, or copy/symlink it into your agent's skills folder.
 
 | Agent | Typical path |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alpaca Skills
 
-Open agent skills for Alpaca's Trading API and Broker API. Each skill is a `SKILL.md` file with step-by-step instructions your AI coding assistant follows when you ask it to complete a task — such as running a historical backtest or fetching market data through the Alpaca CLI.
+Open agent skills for Alpaca's Trading API and Broker API. Each skill is a `SKILL.md` file with step-by-step instructions your AI coding assistant follows when you ask it to complete a task, such as running a historical backtest, onboarding Broker API accounts, moving money, placing orders, or consuming real-time events.
 
 Skills provide shared instructions, guardrails, and reporting standards so agents produce more consistent results across runs.
 
@@ -14,7 +14,7 @@ Skills provide shared instructions, guardrails, and reporting standards so agent
   go install github.com/alpacahq/cli/cmd/alpaca@latest
   ```
 
-- **Alpaca API credentials** — paper or live keys for the CLI. Run `alpaca profile login` or set `ALPACA_API_KEY` and `ALPACA_SECRET_KEY`.
+- **Alpaca API credentials** — paper, sandbox, or live keys as appropriate for the skill. Run `alpaca profile login` for CLI-backed workflows, or set `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` when using API examples.
 
 ## Install
 
@@ -23,9 +23,20 @@ Skills provide shared instructions, guardrails, and reporting standards so agent
 Use the Skills CLI to install from this GitHub repository:
 
 ```bash
+# Interactive install: choose skills and agents in the CLI
+npx skills add alpacahq/alpaca-skills
+
+# Preview available skills without installing
 npx skills add alpacahq/alpaca-skills --list
+
+# Install one specific skill
 npx skills add alpacahq/alpaca-skills --skill alpaca-trading-backtest
+
+# Install all skills non-interactively
+npx skills add alpacahq/alpaca-skills --skill '*'
 ```
+
+Swap in any skill name from the table below.
 
 Agent-specific global installs:
 
@@ -55,7 +66,7 @@ For agents that do not support the Skills CLI, point your agent at a skill direc
 
 | Agent | Typical path |
 | --- | --- |
-| **Cursor** | Copy or symlink `skills/trading-api/backtest/` into `.cursor/skills/` (project) or your user skills directory |
+| **Cursor** | Copy or symlink a skill directory into `.cursor/skills/` (project) or your user skills directory |
 | **Claude Code** | Copy into `~/.claude/skills/` |
 | **Other** | Reference the `SKILL.md` path directly in your agent prompt |
 
@@ -68,16 +79,27 @@ cp -r path/to/alpaca-skills/skills/trading-api/backtest .cursor/skills/alpaca-tr
 
 ## Available skills
 
-| Name | Path | Title |
-| --- | --- | --- |
-| `alpaca-trading-backtest` | [skills/trading-api/backtest/](skills/trading-api/backtest/) | Trading API Backtesting |
+| Name | Path | Title | Product |
+| --- | --- | --- | --- |
+| `alpaca-trading-backtest` | [skills/trading-api/backtest/](skills/trading-api/backtest/) | Trading API Backtesting | Trading API |
+| `alpaca-broker-integration` | [skills/broker-api/integration/](skills/broker-api/integration/) | Broker API Integration | Broker API |
+| `alpaca-broker-account-onboarding` | [skills/broker-api/account-onboarding/](skills/broker-api/account-onboarding/) | Account Onboarding & KYC | Broker API |
+| `alpaca-broker-funding-transfers` | [skills/broker-api/funding-transfers/](skills/broker-api/funding-transfers/) | Funding & Transfers | Broker API |
+| `alpaca-broker-journals` | [skills/broker-api/journals/](skills/broker-api/journals/) | Journals | Broker API |
+| `alpaca-broker-trading-orders` | [skills/broker-api/trading-orders/](skills/broker-api/trading-orders/) | Trading on Behalf of Accounts | Broker API |
+| `alpaca-broker-market-data` | [skills/broker-api/market-data/](skills/broker-api/market-data/) | Market Data | Broker API |
+| `alpaca-broker-sse-events` | [skills/broker-api/sse-events/](skills/broker-api/sse-events/) | Broker SSE Events | Broker API |
+| `alpaca-broker-reconciliation-idempotency` | [skills/broker-api/reconciliation-idempotency/](skills/broker-api/reconciliation-idempotency/) | Reconciliation & Idempotency | Broker API |
+| `alpaca-broker-rate-limits-resilience` | [skills/broker-api/rate-limits-resilience/](skills/broker-api/rate-limits-resilience/) | Rate Limits & Resilience | Broker API |
+| `alpaca-broker-money-precision` | [skills/broker-api/money-precision/](skills/broker-api/money-precision/) | Money & Numeric Precision | Broker API |
 
-Product namespacing uses the folder path (`skills/trading-api/`, `skills/broker-api/`) and the skill `name` field: `alpaca-<product-scope>-<skill-name>` (e.g. `alpaca-trading-backtest`). Use `trading` or `broker` as the product scope — not `api`.
+Product namespacing uses the folder path (`skills/trading-api/`, `skills/broker-api/`) and the skill `name` field: `alpaca-<product-scope>-<skill-name>` (e.g. `alpaca-trading-backtest`, `alpaca-broker-integration`). Use `trading` or `broker` as the product scope — not `api`.
 
 ## Related resources
 
 - [Alpaca CLI](https://github.com/alpacahq/cli)
 - [Trading API documentation](https://docs.alpaca.markets/)
+- [Broker API documentation](https://docs.alpaca.markets/docs/getting-started-with-broker-api)
 - [Alpaca disclosures](https://alpaca.markets/disclosures)
 - [Security policy](SECURITY.md)
 

--- a/skills/broker-api/README.md
+++ b/skills/broker-api/README.md
@@ -1,5 +1,49 @@
 # Broker API Skills
 
-Broker API agent skills will live here. Use skill names like `alpaca-broker-<skill-name>`.
+Broker API agent skills for building on Alpaca: account onboarding, funding, journals, trading on behalf of accounts, market data, SSE events, reconciliation, rate limits, and money precision.
 
-No skills are published yet. See [CONTRIBUTING.md](../../CONTRIBUTING.md) to propose one.
+Start with [`alpaca-broker-integration`](integration/) for base URLs, auth, API-family routing, and cross-cutting conventions. Then load the focused skill for the task.
+
+## Install
+
+List available skills with the Skills CLI:
+
+```bash
+npx skills add alpacahq/alpaca-skills --list
+```
+
+Install a single broker skill:
+
+```bash
+npx skills add alpacahq/alpaca-skills --skill alpaca-broker-integration
+```
+
+Install the full repo into Cursor globally:
+
+```bash
+npx skills add alpacahq/alpaca-skills --skill '*' -g -a cursor -y
+```
+
+For local development from this checkout, use the local path:
+
+```bash
+npx skills add . --list
+npx skills add . --skill alpaca-broker-integration
+```
+
+## Available skills
+
+| Name | Path | Title | Category |
+| --- | --- | --- | --- |
+| `alpaca-broker-integration` | [integration/](integration/) | Broker API Integration | Foundation |
+| `alpaca-broker-account-onboarding` | [account-onboarding/](account-onboarding/) | Account Onboarding & KYC | Broker lifecycle |
+| `alpaca-broker-funding-transfers` | [funding-transfers/](funding-transfers/) | Funding & Transfers | Broker lifecycle |
+| `alpaca-broker-journals` | [journals/](journals/) | Journals | Broker lifecycle |
+| `alpaca-broker-trading-orders` | [trading-orders/](trading-orders/) | Trading on Behalf of Accounts | Broker lifecycle |
+| `alpaca-broker-market-data` | [market-data/](market-data/) | Market Data | Broker lifecycle |
+| `alpaca-broker-sse-events` | [sse-events/](sse-events/) | Broker SSE Events | Real-time |
+| `alpaca-broker-reconciliation-idempotency` | [reconciliation-idempotency/](reconciliation-idempotency/) | Reconciliation & Idempotency | Cross-cutting |
+| `alpaca-broker-rate-limits-resilience` | [rate-limits-resilience/](rate-limits-resilience/) | Rate Limits & Resilience | Cross-cutting |
+| `alpaca-broker-money-precision` | [money-precision/](money-precision/) | Money & Numeric Precision | Cross-cutting |
+
+For contribution rules, see [CONTRIBUTING.md](../../CONTRIBUTING.md) and [AGENTS.md](../../AGENTS.md).

--- a/skills/broker-api/account-onboarding/SKILL.md
+++ b/skills/broker-api/account-onboarding/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: alpaca-broker-account-onboarding
+description: Open and manage brokerage accounts via the Alpaca Broker API — account creation, KYC/CIP, identity & disclosures, agreements, document upload (incl. W-8BEN), account status lifecycle, and account updates/closure. Use when a developer is building onboarding, KYC, or account-management flows on Alpaca in any language.
+---
+
+# Alpaca Broker API — Account Onboarding & KYC
+
+Create and manage end-user brokerage accounts under your firm. This is the **first** step of any Broker API integration: no funding, journaling, or trading can happen until an account reaches `ACTIVE`.
+
+> Read `alpaca-broker-integration` first for base URLs, auth, and conventions. This skill assumes **Broker API + HTTP Basic auth**.
+
+## Reference
+- Guide: `https://docs.alpaca.markets/docs/getting-started-with-broker-api`, `https://docs.alpaca.markets/docs/accounts`
+- API ref: `https://docs.alpaca.markets/reference/createaccount`
+- Live schema: `alpaca-docs` MCP → `get-endpoint` title `"Broker API"` path `/v1/accounts`
+
+## 1. Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/v1/accounts` | Create account (submit application) |
+| GET | `/v1/accounts` | List/query accounts (returns up to 1000) |
+| GET | `/v1/accounts/{account_id}` | Get one account (`AccountExtended`) |
+| PATCH | `/v1/accounts/{account_id}` | Update account |
+| POST | `/v1/accounts/{account_id}/actions/close` | Close account (returns 204) |
+| POST | `/v1/accounts/{account_id}/documents/upload` | Upload owner/KYC documents (array body) |
+| GET | `/v1/accounts/{account_id}/documents` | List uploaded documents |
+| POST / GET | `/v1/accounts/{account_id}/cip` | Submit / retrieve CIP results |
+| GET | `/v1/country-info` | Supported-country data |
+| GET | `/v1/events/accounts/status` | SSE stream of account-status changes → see `alpaca-broker-sse-events` |
+
+## 2. Create-account request (`POST /v1/accounts`)
+
+Four objects are **required**: `contact`, `identity`, `disclosures`, `agreements`. `documents` and `trusted_contact` are optional but usually needed for KYC.
+
+```json
+{
+  "contact": {
+    "email_address": "jane@example.com",
+    "phone_number": "+15555555555",
+    "street_address": ["20 N San Mateo Dr"],
+    "city": "San Mateo",
+    "state": "CA",            // required if country / country_of_tax_residence is USA
+    "postal_code": "94401",
+    "country": "USA"          // ISO 3166-1 alpha-3
+  },
+  "identity": {
+    "given_name": "Jane",
+    "family_name": "Doe",
+    "date_of_birth": "1990-01-01",
+    "tax_id_type": "USA_SSN", // see enum below
+    "tax_id": "666-55-4321",
+    "country_of_tax_residence": "USA",
+    "funding_source": ["employment_income"]
+  },
+  "disclosures": {
+    "is_control_person": false,
+    "is_affiliated_exchange_or_finra": false,
+    "is_politically_exposed": false,
+    "immediate_family_exposed": false
+  },
+  "agreements": [
+    { "agreement": "customer_agreement", "signed_at": "2026-01-02T18:09:33Z", "ip_address": "185.13.21.99" }
+  ],
+  "documents": [ /* OwnerDocumentUploadRequest[] — see §4 */ ],
+  "trusted_contact": { "given_name": "Jim", "family_name": "Doe", "email_address": "jim@example.com" }
+}
+```
+
+**Key field rules:**
+- `contact.street_address` is an **array** (max 3 lines). `contact.state` required when country/tax-residence is `USA`.
+- `identity.funding_source` is an array; one+ of `employment_income`, `investments`, `inheritance`, `business_income`, `savings`, `family`.
+- `tax_id_type` enum is large and country-specific: `USA_SSN`, `USA_ITIN`, `IND_PAN`, `MEX_RFC`, `GBR_NINO`, … plus generic `NATIONAL_ID`, `PASSPORT`, `DRIVER_LICENSE`, `OTHER_GOV_ID`, `NOT_SPECIFIED`. Query the spec for the full list rather than hardcoding.
+- Optional top-level: `account_type` (`trading`|`custodial`|`donor_advised`|`ira`), `account_sub_type` (IRA: `traditional`|`roth`), `enabled_assets` (`us_equity`|`us_option`|`crypto`|`ipo`, default `us_equity`).
+- **Deprecated:** `investment_objective`/`investment_time_horizon`/`liquidity_needs`/`risk_tolerance` moved from `identity` to **top-level**.
+
+**Responses:** `200` → account object · `409` email already registered · `422` invalid value · `400` malformed body.
+
+## 3. Agreements
+
+Each entry: `agreement` (`customer_agreement`, `account_agreement`, `margin_agreement`, `crypto_agreement`, `options_agreement`), `signed_at` (RFC3339), `ip_address` (IPv4), optional `revision`. **You must present the agreement text to the user and capture the real signing timestamp + IP** — Alpaca treats these as the legal record. `revision` defaults to the currently-active revision if omitted.
+
+## 4. Documents & W-8BEN
+
+`documents[]` items: `document_type` + (`content` base64 **or** `content_data`).
+
+```json
+{ "document_type": "identity_verification", "content": "<base64>", "mime_type": "image/jpeg", "document_sub_type": "passport" }
+```
+
+- `document_type` enum includes `identity_verification`, `address_verification`, `date_of_birth_verification`, `tax_id_verification`, `w8ben`, `w9`, `cip_result`, and more.
+- `mime_type`: `application/pdf`, `image/png`, `image/jpeg` — plus `application/json` **only** for `w8ben`.
+- **W-8BEN shortcut (lesson):** instead of generating a PDF, upload `content_data` as a structured `W8benDocument` JSON object (full_name, country_citizen, permanent_address_*, date_of_birth, ip_address, timestamp, signer_full_name, …) and **Alpaca renders the official form for you**. This is the clean way to satisfy the tax-form requirement for non-US persons programmatically.
+- Doc size cap: **10 MB** per file when using Alpaca's KYC-as-a-service; no cap if you run your own KYC.
+
+## 5. Account status lifecycle
+
+`status` (and `crypto_status`) use the `AccountStatus` enum:
+
+| Status | Meaning |
+|--------|---------|
+| `ONBOARDING` | Application expected, not yet submitted |
+| `SUBMITTED` | Submitted, being processed |
+| `SUBMISSION_FAILED` | Submission error |
+| `ACTION_REQUIRED` | Needs manual action (e.g. a `true` disclosure routes here) |
+| `APPROVAL_PENDING` | Approval in progress (documented "initial value") |
+| `APPROVED` | Approved, waiting to go active |
+| `ACTIVE` | **Fully usable** — funding & trading allowed |
+| `REJECTED` | Application rejected |
+| `ACCOUNT_UPDATED` | Modified by user |
+| `ACCOUNT_CLOSED` | Closed |
+| `INACTIVE` | Not enabled for the given asset |
+
+**Happy path:** `SUBMITTED → APPROVAL_PENDING → APPROVED → ACTIVE`.
+
+**Lesson — gate every downstream op on `ACTIVE`.** A `200` from `POST /v1/accounts` does *not* mean tradable. Subscribe to account-status SSE events (or poll `GET /v1/accounts/{id}`) and only enable funding/journals/trading once `status == ACTIVE`. Trying to journal or trade into a non-active account fails.
+
+## 6. KYC results & CIP
+
+- `kyc_results` on the account object carries `reject`/`accept`/`indeterminate` categories (`KYCResultType` values like `IDENTITY_VERIFICATION`, `TAX_IDENTIFICATION`, `ADDRESS_VERIFICATION`, `WATCHLIST_HIT`, `COUNTRY_NOT_SUPPORTED`, `OTHER`) plus `additional_information`. `summary` is `pass`/`fail` (internal only).
+- If you run KYC yourself (or via Onfido/Trulioo/Veriff/etc.), submit results via `POST /v1/accounts/{id}/cip` with a `CIPInfo` body (provider_name, kyc, document, photo, identity, watchlist sub-results). Sub-check results are `clear`/`consider`.
+- Minimum to open an individual account: verify **name, date of birth, address, and identification number**.
+- `WATCHLIST_HIT` / `COUNTRY_NOT_SUPPORTED` require no user action — Alpaca handles them manually.
+
+## 7. Integration guidance & lessons learned
+
+1. **Normalize inputs to canonical formats before sending.** Country fields must be **ISO 3166-1 alpha-3** (`USA`, `PHL`, …) — strip any UI decoration (flags/emoji, display names) and validate against `GET /v1/country-info`. Garbage in `country`/`country_of_tax_residence` is a common 422.
+2. **Capture real agreement metadata.** `signed_at` and `ip_address` must reflect the actual user action, not server time / a placeholder.
+3. **Treat creation as async.** Persist the returned `account_id` immediately, then drive UI off the **status events**, not the create response.
+4. **Guard against paper/test accounts in production code paths.** If you run both sandbox and live, make sure live event handlers reject sandbox/paper account IDs rather than silently mutating real records.
+5. **Idempotency on submit.** A `409` on duplicate email is your friend — look up the existing account rather than retrying creation. Store your local user↔`account_id` mapping before the network call so a timeout doesn't orphan an account.
+6. **Closing is your responsibility to sequence.** Before `POST .../actions/close`, you must liquidate all positions and withdraw all cash. The account record is not deleted — it goes `ACCOUNT_CLOSED`.
+
+**Related skills:** fund the account → `alpaca-broker-funding-transfers`; move cash in via the firm sweep → `alpaca-broker-journals`; trade → `alpaca-broker-trading-orders`; track status in real time → `alpaca-broker-sse-events`.

--- a/skills/broker-api/account-onboarding/reference.md
+++ b/skills/broker-api/account-onboarding/reference.md
@@ -1,0 +1,21 @@
+# Account Onboarding & KYC Reference
+
+Companion to `SKILL.md`. Read the workflow and guardrails there first.
+
+## Primary docs and schemas
+
+- Guide: `https://docs.alpaca.markets/docs/getting-started-with-broker-api`, `https://docs.alpaca.markets/docs/accounts`
+- API ref: `https://docs.alpaca.markets/reference/createaccount`
+- Live schema: `alpaca-docs` MCP → `get-endpoint` title `"Broker API"` path `/v1/accounts`
+
+## Live schema workflow
+
+Prefer live Alpaca documentation before generating code that opens accounts, moves money, places orders, or mutates production state:
+
+1. Check `https://docs.alpaca.markets/llms.txt` or `https://docs.alpaca.markets/llms-full.txt` for the current documentation index.
+2. If an `alpaca-docs` MCP server is connected, use it for exact endpoint schemas instead of guessing from examples.
+3. Verify required fields, enum values, pagination, and status transitions against the current Broker API, Trading API, or Market Data API spec.
+
+## Related broker skills
+
+`alpaca-broker-integration`, `alpaca-broker-funding-transfers`, `alpaca-broker-journals`, `alpaca-broker-trading-orders`, `alpaca-broker-market-data`, `alpaca-broker-sse-events`, `alpaca-broker-reconciliation-idempotency`, `alpaca-broker-rate-limits-resilience`, `alpaca-broker-money-precision`

--- a/skills/broker-api/funding-transfers/SKILL.md
+++ b/skills/broker-api/funding-transfers/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: alpaca-broker-funding-transfers
+description: Move money between an Alpaca brokerage account and the EXTERNAL banking world via the Broker API — ACH relationships, wire recipient banks, classic transfers (deposits/withdrawals), the v1beta funding wallet (international/instant), transfer status lifecycles, and fees. Use when building deposit/withdrawal flows or connecting external bank accounts on Alpaca in any language. For moving cash/shares BETWEEN accounts inside your own omnibus, use journals instead.
+---
+
+# Alpaca Broker API — Funding & Transfers
+
+Getting cash into and out of end-user accounts. There are **three rails**, and the model splits cleanly into *bank links* (persistent) and *transfers* (the actual money movement).
+
+> Read `alpaca-broker-integration` first. Broker API + HTTP Basic auth. For moving cash *between* accounts in your omnibus (vs. to/from the outside world), see `alpaca-broker-journals` — that's a different mechanism.
+
+## Reference
+- Guide: `https://docs.alpaca.markets/docs/funding-accounts`
+- API ref: `https://docs.alpaca.markets/reference/createtransferforaccount`
+- Live schema: `alpaca-docs` MCP → `get-endpoint` title `"Broker API"` path `/v1/accounts/{account_id}/transfers`
+
+## 1. The funding model
+
+```
+External bank ──(relationship: a persistent link)──┐
+                                                    ├──> Transfer (the money movement) ──> Account cash
+ACH relationship  (rail A: ACH, US domestic)        │
+Bank relationship (rail B: wire, domestic + intl)   │
+Funding wallet    (rail C: v1beta, multi-currency)  ┘
+```
+
+- A **relationship** links an external bank. It moves no money and has its own status; for wires it must be `APPROVED` before a transfer can progress.
+- A **transfer** references a relationship by ID and moves the money. One relationship backs many transfers.
+
+| Rail | `transfer_type` | Directions | Relationship | Notes |
+|------|-----------------|-----------|--------------|-------|
+| **ACH** | `ach` | `INCOMING` + `OUTGOING` | ACH relationship (`relationship_id`) | US domestic; set up via Plaid `processor_token` (recommended) |
+| **Wire** | `wire` | `OUTGOING` only | Bank relationship (`bank_id`) | Domestic + international (SWIFT). Incoming wires are pushed by the sending bank and booked automatically |
+| **Funding wallet** | (separate `/v1beta` API) | `incoming` / `outgoing` (lowercase) | Funding-wallet recipient bank | Multi-currency, `swift_wire`/`local_rails` |
+
+## 2. Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST/GET/DELETE | `/v1/accounts/{id}/ach_relationships[/{rel_id}]` | Manage ACH bank links |
+| POST/GET/DELETE | `/v1/accounts/{id}/recipient_banks[/{bank_id}]` | Manage wire recipient banks |
+| POST | `/v1/accounts/{id}/transfers` | Create transfer (ACH deposit/withdraw, or wire withdraw) |
+| GET | `/v1/accounts/{id}/transfers` | List transfers |
+| DELETE | `/v1/accounts/{id}/transfers/{transfer_id}` | Request cancel |
+| POST/GET | `/v1beta/accounts/{id}/funding_wallet` | Create / get funding wallet |
+| POST/GET/DELETE | `/v1beta/accounts/{id}/funding_wallet/recipient_bank` | Funding-wallet recipient bank |
+| POST | `/v1beta/accounts/{id}/funding_wallet/withdrawal` | Funding-wallet withdrawal |
+| GET | `/v1beta/accounts/{id}/funding_wallet/transfers[/{transfer_id}]` | List / get wallet transfers |
+| GET | `/v2/events/funding/status` | **SSE** — unified funding status stream (see §6) |
+
+> The current wire-bank endpoint is **`/recipient_banks`** (schema `Bank`/`CreateBankRequest`). The older `/banks` name is a legacy alias.
+
+## 3. Create-transfer request (`POST /v1/accounts/{id}/transfers`)
+
+Required for all: `transfer_type`, `amount` (decimal **string**, > 0), `direction`.
+
+```json
+// ACH deposit
+{ "transfer_type": "ach", "relationship_id": "<uuid>", "amount": "100.00", "direction": "INCOMING" }
+
+// Wire withdrawal
+{ "transfer_type": "wire", "bank_id": "<uuid>", "amount": "500.00", "direction": "OUTGOING",
+  "fee_payment_method": "user", "additional_information": "..." }
+```
+
+- `relationship_id` required iff `ach`; `bank_id` required iff `wire` (and must be the *other* one's empty).
+- `fee_payment_method` (wire): `user` (fee deducted from `amount`; warn the user in UI) or `invoice` (firm billed monthly). Only **outgoing** wire fees auto-process.
+- `additional_information` is wire-only — sending it on a non-wire request returns `422`.
+- The `Transfer` response adds `id`, `status`, `fee`, `requested_amount` (original ask), `reason`, timestamps.
+
+## 4. Wire recipient bank (`POST /v1/accounts/{id}/recipient_banks`)
+
+Required: `name`, `bank_code`, `bank_code_type`, `account_number`.
+
+- `bank_code_type`: `ABA` (9-digit routing, domestic) or `BIC` (SWIFT, international).
+- When `BIC`: `country`, `city`, `state_province`, `postal_code`, `street_address` become required.
+- `extra_fields` carries intermediary/correspondent BICs (`intermediary_bank1_bic`…). **Omitting them on international wires can cause auto-selection, delays, or extra fees** — gather them up front for cross-border.
+- A new bank starts `QUEUED`; it must reach `APPROVED` before a wire transfer against it progresses.
+
+## 5. Transfer status state machines
+
+**Classic transfers (`TransferStatus`):**
+`QUEUED → APPROVAL_PENDING → PENDING → SENT_TO_CLEARING → (APPROVED) → COMPLETE`, with `REJECTED` / `CANCELED` / `RETURNED` as failure exits.
+
+| Terminal | Meaning |
+|----------|---------|
+| `COMPLETE` | Settled |
+| `REJECTED` | Rejected |
+| `CANCELED` | Client-initiated cancel |
+| `RETURNED` | Bank issued an ACH return |
+
+(The SSE `Transfer` entity also reports `EXPIRED`, which is effectively terminal.)
+
+**Funding-wallet transfers (`FundingWalletTransferStatus`):** `PENDING`, `EXECUTED`, `COMPLETE`, `CANCELED`, `FAILED` (last three terminal). Note lowercase `incoming`/`outgoing` directions here — different casing from classic transfers.
+
+## 6. Events vs polling — the key reliability lesson
+
+**Classic transfers HAVE an SSE stream:** `GET /v2/events/funding/status`. It is unified across four `entity_type` values — `Transfer`, `BankRelationship`, `WireBank`, `FundingWallet` — and is **replayable** via `since`/`until` (timestamps) or `since_id`/`until_id` (ULIDs). Use it instead of polling for classic ACH/wire status.
+
+**Funding-wallet *per-transfer* status appears NOT to be pushed** — only wallet-level status (`active`/`pending`) is in the stream. Individual wallet transfer status (`PENDING→EXECUTED→COMPLETE`) must be **polled** via `GET /v1beta/.../funding_wallet/transfers/{id}`.
+
+**Lesson (hard-won):** rails differ in event coverage. Decide per rail whether you consume SSE or poll, and build a **status-reconciliation poller** for anything not covered by events (and as a safety net even for those that are — SSE can drop). Map each Alpaca status to your own internal status with an explicit lookup table, and only poll transfers still in a **non-terminal** state. See `alpaca-broker-reconciliation-idempotency`.
+
+> Legacy caveat: the older `us/sse-events` "Transfer Events" payload uses an **integer** `event_id` and lowercase statuses; the modern `/v2/events/funding/status` uses ULIDs. Migrate to v2.
+
+## 7. Documented gotchas
+
+- **Wire fees (since 2022-06-01):** outgoing domestic + international wires are charged. Reflect `requested_amount` vs `amount`+`fee` in your UI.
+- **Incoming wires need an FFC (For Further Credit) instruction** to auto-book; otherwise they're handled manually.
+- **Travel Rule:** Alpaca requires transmitter/originator info on **all incoming deposits regardless of amount** (below the usual FinCEN $3,000 threshold). Pass it at settlement creation; retained ≥5 years.
+- **ACH uses Plaid:** pass the bank via `processor_token`. There's an `instant` flag on the relationship. Account types limited to `CHECKING`/`SAVINGS`.
+- **`timing: immediate` is deprecated** and silently ignored (sunset 2026-08-26) — stop sending it.
+- **Permission errors:** `403` if the account's `depositable_status`/`withdrawable_status` isn't allowed; `422` for incoming-wire attempts, missing/mismatched relationship vs bank IDs, or amounts under the (undocumented) minimums.
+- **Sandbox wire behavior:** simulated end-to-end but **asynchronous** and auto-completes **on weekdays only** — weekend submissions don't progress until Monday. (ACH in sandbox settles instantly.)
+
+## 8. The omnibus / sweep-account pattern (architecture lesson)
+
+Many production brokers don't fund each user account by a separate external transfer. Instead:
+
+1. Users pay you through *your* payment processor (or you receive a bulk wire into a **firm/sweep account** held at Alpaca).
+2. You then **journal** cash from the firm account to the user's account instantly (`JNLC`) — no external ACH/wire per user. See `alpaca-broker-journals`.
+3. Withdrawals reverse it: journal from user → firm account, then send one external transfer out.
+
+This decouples your funding UX from Alpaca's transfer rails and enables "instant" deposits. It requires Alpaca review (and possibly a local money-transmitter license) — confirm with counsel. The classic transfer endpoints in this skill then handle only the *firm-account-to-outside-world* leg.
+
+**Related skills:** internal cash movement → `alpaca-broker-journals`; missed-status recovery → `alpaca-broker-reconciliation-idempotency`; money formatting → `alpaca-broker-money-precision`; live status → `alpaca-broker-sse-events`.

--- a/skills/broker-api/funding-transfers/reference.md
+++ b/skills/broker-api/funding-transfers/reference.md
@@ -1,0 +1,21 @@
+# Funding & Transfers Reference
+
+Companion to `SKILL.md`. Read the workflow and guardrails there first.
+
+## Primary docs and schemas
+
+- Guide: `https://docs.alpaca.markets/docs/funding-accounts`
+- API ref: `https://docs.alpaca.markets/reference/createtransferforaccount`
+- Live schema: `alpaca-docs` MCP → `get-endpoint` title `"Broker API"` path `/v1/accounts/{account_id}/transfers`
+
+## Live schema workflow
+
+Prefer live Alpaca documentation before generating code that opens accounts, moves money, places orders, or mutates production state:
+
+1. Check `https://docs.alpaca.markets/llms.txt` or `https://docs.alpaca.markets/llms-full.txt` for the current documentation index.
+2. If an `alpaca-docs` MCP server is connected, use it for exact endpoint schemas instead of guessing from examples.
+3. Verify required fields, enum values, pagination, and status transitions against the current Broker API, Trading API, or Market Data API spec.
+
+## Related broker skills
+
+`alpaca-broker-integration`, `alpaca-broker-account-onboarding`, `alpaca-broker-journals`, `alpaca-broker-trading-orders`, `alpaca-broker-market-data`, `alpaca-broker-sse-events`, `alpaca-broker-reconciliation-idempotency`, `alpaca-broker-rate-limits-resilience`, `alpaca-broker-money-precision`

--- a/skills/broker-api/integration/SKILL.md
+++ b/skills/broker-api/integration/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: alpaca-broker-integration
+description: Entry point for integrating with the Alpaca Broker API (plus Market Data and Trading APIs) in any programming language. Use when a developer wants to build on Alpaca — open brokerage accounts, run KYC, fund accounts, move money via journals, place orders, consume real-time event streams, or pull market data — and need to know base URLs, auth, conventions, or which focused sub-skill to use.
+---
+
+# Alpaca Integration Assistant
+
+You are an expert on the **Alpaca** APIs. Help developers integrate with Alpaca in **any programming language**. Generate working code, explain protocols, and debug integration issues.
+
+This is the **router / overview** skill. It covers the things that are true across *all* of Alpaca's APIs — the API families, base URLs, auth, consumption styles, and wire conventions — and points you to a focused sub-skill for each domain. Read this first, then jump to the specific skill for the task.
+
+> Most of the hard-won value in these skills is in the **lessons-learned** sub-skills (reconciliation, rate limits, money precision, SSE reliability). Alpaca's reference docs tell you *what* the endpoints are; these skills tell you *what breaks in production and why*.
+
+---
+
+## Reference Documentation
+
+- Docs home: `https://docs.alpaca.markets/`
+- API reference: `https://docs.alpaca.markets/reference/`
+- Machine-readable index: `https://docs.alpaca.markets/llms.txt` and `https://docs.alpaca.markets/llms-full.txt`
+- OpenAPI specs (4): **Authentication API**, **Broker API**, **Market Data API**, **Trading API**
+
+**Live schema lookups:** if the `alpaca-docs` MCP server is connected, prefer it over guessing — `list-specs`, `list-endpoints`, `get-endpoint` (exact request/response schemas + servers), and `search` / `fetch` (guide pages). Always confirm an exact payload against the spec before generating code that posts money or orders.
+
+---
+
+## 1. The four API families
+
+| Family | What it's for | Who uses it |
+|--------|---------------|-------------|
+| **Broker API** | Open & manage brokerage accounts on behalf of *your* end users (KYC, funding, journals, trading-for-accounts, documents, events). You are the broker-of-record's tech partner; you custody many sub-accounts under your firm. | Apps that onboard their own users and hold their assets (neobrokers, fintechs). |
+| **Trading API** | Trade a *single* account that belongs to the API-key holder. | Individual algo traders, bots. |
+| **Market Data API** | Real-time + historical prices, bars, quotes, trades, news, corporate actions, screener. REST and WebSocket. | Everyone. |
+| **Authentication API** | OAuth 2.0 flows for letting third parties act on an Alpaca account. | OAuth integrations. |
+
+**Decide first which family you're on — it changes the base URL, the auth, and the URL shape of every call.** The most common confusion: Broker API places orders at `/v1/trading/accounts/{account_id}/orders` (the account is in the path because you act *for* a user), whereas the standalone Trading API places orders at `/v2/orders` (implicitly *your own* account).
+
+These skills focus primarily on the **Broker API**, because that's where the lifecycle is hardest: onboarding, funding rails, journals, and event reconciliation.
+
+---
+
+## 2. Base URLs
+
+| Family | Production | Sandbox / Paper |
+|--------|-----------|-----------------|
+| **Broker API** | `https://broker-api.alpaca.markets` | `https://broker-api.sandbox.alpaca.markets` |
+| **Trading API** | `https://api.alpaca.markets` | `https://paper-api.alpaca.markets` (paper) |
+| **Market Data (REST)** | `https://data.alpaca.markets` | *(same host; sandbox data is limited)* |
+| **Market Data (WebSocket)** | `wss://stream.data.alpaca.markets` | `wss://stream.data.sandbox.alpaca.markets` |
+
+**Always start in sandbox.** Switch by environment variable, never by code path — a single `ENV` flag that selects the base URL is the pattern that survives. Sandbox accounts can be funded with fake money and auto-approved, so you can exercise the full lifecycle without real KYC or cash.
+
+---
+
+## 3. Authentication
+
+Auth differs **by API family** — this trips people up constantly.
+
+### Broker API → HTTP Basic
+
+```
+Authorization: Basic base64("<API_KEY_ID>:<API_SECRET_KEY>")
+```
+
+The same Basic credential authenticates Broker REST, Broker SSE event streams, and trading-on-behalf-of-accounts. Build the base64 token **once** at startup; don't recompute per request.
+
+### Market Data API → key/secret headers (or Basic in broker context)
+
+```
+APCA-API-KEY-ID: <API_KEY_ID>
+APCA-API-SECRET-KEY: <API_SECRET_KEY>
+```
+
+For the WebSocket data stream, you don't use headers — you send an auth message *after* connecting:
+```json
+{"action": "auth", "key": "<API_KEY_ID>", "secret": "<API_SECRET_KEY>"}
+```
+
+> Broker API partners can usually authenticate market-data calls with their **Broker Basic** credentials too. Pick one scheme per data client and be consistent; mixing them is a frequent source of 401s.
+
+### Trading API → key/secret headers
+Same `APCA-API-*` headers as market data.
+
+### Authentication API → OAuth 2.0 Bearer
+For OAuth integrations, exchange the code for a token and send `Authorization: Bearer <token>`.
+
+---
+
+## 4. Three consumption styles
+
+Alpaca gives you three transports. Use the right one for the job — and know that they have **different auth and different reliability characteristics**.
+
+| Style | Transport | Use for | Skill |
+|-------|-----------|---------|-------|
+| **REST** | HTTPS request/response | Everything transactional: create account, fund, journal, place order, query state. | the domain skills |
+| **SSE** | `text/event-stream` over a long-lived HTTPS GET | Broker lifecycle events: account status, journals, transfers, trades, non-trade activities. **Replayable** via cursors. | `alpaca-broker-sse-events` |
+| **WebSocket** | `wss://` | Real-time market data (trades/quotes/bars). | `alpaca-broker-market-data` |
+
+**Key distinction:** Broker *events* come over **SSE** (simple HTTP, Basic auth, replayable with `since`/`since_id`). Market *data* comes over **WebSocket** (subscribe model, auth message, ping/pong). They are different endpoints with different auth — don't conflate them.
+
+---
+
+## 5. Wire conventions (true across the platform)
+
+These apply everywhere and are the source of most subtle bugs:
+
+- **Numbers are strings.** Prices, quantities, notional, and money amounts come back as JSON strings (`"100.50"`, `"1.5"`). Parse into a decimal type, never a binary float. See `alpaca-broker-money-precision`.
+- **IDs:** `account_id`, `order_id`, `journal_id`, `transfer_id` are UUIDs. Activity IDs and newer event IDs are **ULIDs** — lexicographically sortable, which matters for event ordering and replay cursors.
+- **Idempotency:** pass your own `client_order_id` on orders so retries don't double-fill. Records you create from events should be keyed on the Alpaca ID with upsert/skip-duplicate semantics. See `alpaca-broker-reconciliation-idempotency`.
+- **Pagination:** list endpoints page forward with a token. Market-data bars return `next_page_token` in the body; activities return a page token via the `X-Next-Page-Token` response header. Loop until the token is empty.
+- **Rate limits:** responses carry `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (unix seconds). On HTTP `429`, wait until reset before retrying. See `alpaca-broker-rate-limits-resilience`.
+- **Timestamps:** RFC3339 (e.g. `2026-01-02T15:04:05Z`). SSE `since`/`until` accept RFC3339, but `+` in a timezone offset must be URL-encoded as `%2B`.
+- **Status ≠ done.** Almost every write (account, journal, transfer, order) is asynchronous and moves through a **state machine**. A `200` means "accepted," not "settled." Always reconcile on the terminal status, which arrives later via event or poll.
+
+---
+
+## 6. Sandbox-first workflow
+
+When helping someone start from zero, walk them through this order:
+
+1. **Pick sandbox URLs** via an `ENV` switch.
+2. **Authenticate** with Basic (Broker) — verify with `GET /v1/accounts` (list).
+3. **Create an account** with full KYC payload → `alpaca-broker-account-onboarding`.
+4. **Wait for `ACTIVE`** status (via SSE account-status events or polling) before any money/trade op.
+5. **Fund it** (sandbox lets you simulate deposits) → `alpaca-broker-funding-transfers`.
+6. **Move cash where it's needed** with journals → `alpaca-broker-journals`.
+7. **Place an order** → `alpaca-broker-trading-orders`.
+8. **Subscribe to events** to track fills/transfers in real time → `alpaca-broker-sse-events`.
+9. **Add a reconciliation pass** before going live → `alpaca-broker-reconciliation-idempotency`.
+
+---
+
+## 7. Skill map — where to go next
+
+| If the task is about… | Use skill |
+|-----------------------|-----------|
+| Creating accounts, KYC, CIP, document upload, agreements, account status, W-8BEN | **`alpaca-broker-account-onboarding`** |
+| ACH / wire / funding-wallet rails, deposits, withdrawals, transfer status, the omnibus/float-account model | **`alpaca-broker-funding-transfers`** |
+| Moving cash (JNLC) or shares (JNLS) between accounts, batch & reverse-batch, journal lifecycle | **`alpaca-broker-journals`** |
+| Placing/canceling orders, qty vs notional, fractional shares, order lifecycle, positions, recurring buys | **`alpaca-broker-trading-orders`** |
+| Snapshots, bars, quotes, assets, news, market clock/calendar, feeds (IEX/SIP), WebSocket price streams | **`alpaca-broker-market-data`** |
+| Consuming Broker SSE event streams reliably (reconnect, heartbeats, replay cursors) | **`alpaca-broker-sse-events`** |
+| Keeping local state correct: missed-event recovery, polling rails without webhooks, idempotency, status guards | **`alpaca-broker-reconciliation-idempotency`** |
+| Backoff, 429 handling, rate-limit headers, concurrency limits, batch sizing | **`alpaca-broker-rate-limits-resilience`** |
+| Handling money correctly: decimals vs floats, numbers-as-strings, truncation/rounding | **`alpaca-broker-money-precision`** |
+
+---
+
+## 8. Integration guidance (applies regardless of language)
+
+1. **One base-URL switch, environment-driven.** Never hardcode prod URLs in a code branch.
+2. **Build auth once.** Cache the Basic token / header set at client construction.
+3. **Treat every write as async.** Model the state machine; act on terminal states, not on the `2xx`.
+4. **Persist Alpaca's IDs.** Store `account_id`, `order_id`, `journal_id`, `transfer_id` on your local records — they are your only correlation key for events and reconciliation.
+5. **Decimals, not floats**, for anything monetary. Parse the string fields into a decimal type.
+6. **Reconcile, don't trust the stream.** SSE can drop events; design a polling/heal pass that re-syncs from Alpaca as source of truth (`alpaca-broker-reconciliation-idempotency`).
+7. **Respect rate limits proactively.** Watch `X-RateLimit-Remaining`, back off before you get throttled.
+8. **Use `client_order_id`** and Alpaca-ID-keyed upserts so retries and duplicate events are safe.
+
+### Language notes (transport only — Alpaca is HTTP/SSE/WS, so any stack works)
+
+- **Python:** `httpx`/`requests` (REST), `httpx`/`aiohttp` or an SSE client for events, `websockets` for data, `decimal.Decimal` for money.
+- **TypeScript/Node:** `fetch` (REST), an `EventSource` implementation for SSE (pass the `Authorization` header), `ws` for WebSocket, decimal-as-string or `decimal.js`.
+- **Go:** `net/http` (REST + SSE via a streaming `bufio.Scanner`), `gorilla/websocket` for data; be deliberate about money types (`shopspring/decimal` if precision matters).
+- **Any language:** SSE is just a long-lived HTTP GET that yields `text/event-stream`; if no SSE client exists, read the response body line-by-line and parse `data:` frames.
+
+Alpaca also publishes official SDKs (`alpaca-py`, `@alpacahq/alpaca-trade-api` / `typescript-sdk`, Go community SDKs). Offer them when the user wants speed, but these skills teach the **wire protocol** so the knowledge transfers to any language or a custom client.

--- a/skills/broker-api/integration/reference.md
+++ b/skills/broker-api/integration/reference.md
@@ -1,0 +1,22 @@
+# Broker API Integration Reference
+
+Companion to `SKILL.md`. Read the workflow and guardrails there first.
+
+## Primary docs and schemas
+
+- Docs home: `https://docs.alpaca.markets/`
+- API reference: `https://docs.alpaca.markets/reference/`
+- Machine-readable index: `https://docs.alpaca.markets/llms.txt` and `https://docs.alpaca.markets/llms-full.txt`
+- OpenAPI specs: Authentication API, Broker API, Market Data API, Trading API
+
+## Live schema workflow
+
+Prefer live Alpaca documentation before generating code that opens accounts, moves money, places orders, or mutates production state:
+
+1. Check `https://docs.alpaca.markets/llms.txt` or `https://docs.alpaca.markets/llms-full.txt` for the current documentation index.
+2. If an `alpaca-docs` MCP server is connected, use it for exact endpoint schemas instead of guessing from examples.
+3. Verify required fields, enum values, pagination, and status transitions against the current Broker API, Trading API, or Market Data API spec.
+
+## Related broker skills
+
+`alpaca-broker-account-onboarding`, `alpaca-broker-funding-transfers`, `alpaca-broker-journals`, `alpaca-broker-trading-orders`, `alpaca-broker-market-data`, `alpaca-broker-sse-events`, `alpaca-broker-reconciliation-idempotency`, `alpaca-broker-rate-limits-resilience`, `alpaca-broker-money-precision`

--- a/skills/broker-api/journals/SKILL.md
+++ b/skills/broker-api/journals/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: alpaca-broker-journals
+description: Move cash (JNLC) and securities (JNLS) BETWEEN accounts inside your own Alpaca omnibus via the Broker API — single, batch, and reverse-batch journals, the Idempotency-Key header, journal status lifecycle including corrections, and the firm/sweep-account pattern that powers instant funding and share rewards. Use for internal account-to-account movement in any language. For deposits/withdrawals to EXTERNAL banks, use funding-transfers instead.
+---
+
+# Alpaca Broker API — Journals
+
+Journals move value **between two accounts within your own Alpaca omnibus** — typically between a pre-funded firm/sweep account and a user account. They are the engine behind "instant funding," cashback, and share rewards. They never touch the outside banking world (that's `alpaca-broker-funding-transfers`).
+
+> Read `alpaca-broker-integration` first. Broker API + HTTP Basic auth.
+
+## Reference
+- Guide: `https://docs.alpaca.markets/docs/funding-via-journals`
+- API ref: `https://docs.alpaca.markets/reference/createjournal`
+- Live schema: `alpaca-docs` MCP → `get-endpoint` title `"Broker API"` path `/v1/journals`
+
+## 1. Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/v1/journals` | Single journal (JNLC cash or JNLS shares) |
+| POST | `/v1/journals/batch` | One source → many destinations (JNLC only) |
+| POST | `/v1/journals/reverse_batch` | Many sources → one destination (JNLC only) |
+| GET | `/v1/journals` | List (filters: `after`, `before`, `status`, `entry_type`, `to_account`, `from_account`, `limit`) |
+| GET | `/v1/journals/{journal_id}` | Retrieve one |
+| DELETE | `/v1/journals/{journal_id}` | Cancel a **pending** journal (204) |
+| GET | `/v2/events/journals/status` | **SSE** journal status stream (v1 is legacy) |
+
+## 2. JNLC vs JNLS
+
+`entry_type` is exactly `"JNLC"` or `"JNLS"`.
+
+- **`JNLC` — cash.** Moves USD between accounts. Allowed **firm ↔ user, both directions**. Not customer-to-customer.
+- **`JNLS` — securities.** Moves whole/fractional shares. Allowed **firm → user only**. Used for signup/referral share rewards.
+
+```json
+// JNLC (cash)
+{ "entry_type": "JNLC", "from_account": "<firm-uuid>", "to_account": "<user-uuid>", "amount": "100.00" }
+
+// JNLS (shares)
+{ "entry_type": "JNLS", "from_account": "<firm-uuid>", "to_account": "<user-uuid>", "symbol": "AAPL", "qty": "0.5" }
+```
+
+| Field | JNLC | JNLS | Notes |
+|-------|------|------|-------|
+| `from_account` / `to_account` | required | required | account UUIDs |
+| `amount` | **required** | — | decimal string |
+| `symbol` / `qty` | — | **required** | qty is a string; fractional allowed |
+| `currency` | optional | optional | defaults USD |
+| `description` | optional | optional | ≤1024 chars; accepts sandbox fixtures |
+| `transmitter_*` | optional (JNLC) | n/a | Travel Rule fields |
+
+**Responses:** `200` journal · `403` amount/assets not available · `404` account not found · `422` idempotency-key reused with a different body.
+
+## 3. Idempotency-Key header — USE IT
+
+Pass an `Idempotency-Key` header (≤128 chars; a client-generated UUID is recommended) on journal creates.
+
+- Same key + **identical** body → returns the original journal (no duplicate).
+- Same key + **different** body → `422`.
+
+**Lesson:** this is the correct way to make money movement retry-safe. Without it, a network timeout on `POST /v1/journals` leaves you unsure whether the cash moved — and a blind retry can double-fund. Generate the key deterministically from your own transaction ID and send it on every attempt.
+
+## 4. Batch vs reverse-batch (JNLC only, all-or-nothing)
+
+**Batch — one-to-many** (fan a sweep account out to many users):
+```json
+{ "entry_type": "JNLC", "from_account": "<firm-uuid>",
+  "entries": [ { "to_account": "<u1>", "amount": "1000" }, { "to_account": "<u2>", "amount": "250" } ] }
+```
+
+**Reverse batch — many-to-one** (pull cash from many users back to the firm account):
+```json
+{ "entry_type": "JNLC", "to_account": "<firm-uuid>",
+  "entries": [ { "from_account": "<u1>", "amount": "10" }, { "from_account": "<u2>", "amount": "100" } ] }
+```
+
+Every entry must validate or the **entire batch fails** (one bad account ID kills it). The response is an array of `BatchJournalResponse` (the Journal object + an `error_message` per entry that failed). `Idempotency-Key` is supported with the same semantics.
+
+## 5. Status lifecycle
+
+`JournalStatus`: `queued`, `sent_to_clearing`, `pending`, `executed`, `rejected`, `canceled`, `refused`, `deleted`, `correct`.
+
+**Happy path:** `queued → sent_to_clearing → executed`.
+
+| Status | Meaning | Terminal |
+|--------|---------|----------|
+| `queued` | In queue | no |
+| `sent_to_clearing` | Submitted to books-and-records | no |
+| `pending` | Needs Alpaca ops approval (e.g. hit a JNLC daily limit) | no |
+| `executed` | Balances updated — **but NOT final**, can still be reversed by cashiering | no (not final) |
+| `rejected` | Manually rejected | no |
+| `refused` | Failed preliminary checks; never hit the ledger (e.g. a fast replay failing the balance check) | no |
+| `canceled` | Canceled via API/ops | **FINAL** |
+| `deleted` | Removed from ledger | **FINAL** |
+| `correct` | A prior executed journal was cancelled and re-created with a corrected amount | **FINAL** |
+
+**Two critical lessons:**
+1. **`executed` ≠ final.** Don't treat `executed` as irreversible — Alpaca cashiering can reverse a journal that wasn't permitted. Reconcile against later events.
+2. **`correct` creates a NEW journal ID.** A correction cancels the original and issues a *new* journal with the corrected amount — it is **not** an in-place edit. If you reconcile by journal ID, the original ID transitions to `correct`/cancelled while a *different* ID carries the real funds. Handle both. (This is why event consumers must be idempotent and ID-keyed — see `alpaca-broker-reconciliation-idempotency`.)
+
+## 6. SSE journal events
+
+`GET /v2/events/journals/status` pushes `JournalStatusEventV2`: `event_id` (ULID, sortable), `journal_id`, `entry_type`, `status_from`, `status_to`, `description`, `idempotency_key`, `idempotency_key_type` (`single`|`batch`), `batch_error_message`. Replay rules: `since` required if `until` set; `since_id` required if `until_id` set; can't mix `since` with `since_id`. Without a `since`/`since_id`, no history is returned. See `alpaca-broker-sse-events`.
+
+## 7. Constraints & gotchas
+
+- **Eligibility:** the cash-pooling/journals use case requires Alpaca review and possibly a local license — check with counsel.
+- **JNLS account states:** `to_account` must be `ACTIVE`; `from_account` must be `ACTIVE` or `CLOSE`.
+- **Sufficient funds:** JNLC create → `403` if the amount isn't available; reverse-batch `403` = insufficient balance/assets.
+- **Daily limits push to `pending`** (manual ops approval).
+- **`GET /v1/journals` returns `422` if the result set exceeds 100,000 records** — always filter with `after`/`before`/`limit`.
+- **Delete is pending-only:** `DELETE` succeeds (204) only when `pending`; an executed journal → `422`. **To reverse an executed journal, create a mirror journal in the opposite direction**, don't try to delete it.
+- **Travel Rule:** include transmitter info on money-moving journals (required on all incoming deposits regardless of amount).
+- **Sandbox fixtures:** put fixtures in `description` (e.g. `/fixtures/status=rejected/fixtures/`) to simulate `rejected`/`pending` outcomes for testing.
+
+## 8. The sweep-account funding pattern (why journals exist)
+
+The canonical Broker API funding architecture:
+
+```
+Bulk external wire ──> FIRM / SWEEP account (pre-funded) ──JNLC──> user accounts (instant)
+user account ──JNLC──> FIRM account ──external wire/ACH──> outside world (withdrawal)
+```
+
+You collect money your own way, hold it in a firm account, and **journal it to users instantly** rather than running a per-user external transfer. Withdrawals reverse the flow. This is what makes "instant deposit" UX possible on top of slow banking rails.
+
+**Related skills:** external money in/out → `alpaca-broker-funding-transfers`; retry-safety & corrections → `alpaca-broker-reconciliation-idempotency`; decimal handling → `alpaca-broker-money-precision`; events → `alpaca-broker-sse-events`.

--- a/skills/broker-api/journals/reference.md
+++ b/skills/broker-api/journals/reference.md
@@ -1,0 +1,21 @@
+# Journals Reference
+
+Companion to `SKILL.md`. Read the workflow and guardrails there first.
+
+## Primary docs and schemas
+
+- Guide: `https://docs.alpaca.markets/docs/funding-via-journals`
+- API ref: `https://docs.alpaca.markets/reference/createjournal`
+- Live schema: `alpaca-docs` MCP → `get-endpoint` title `"Broker API"` path `/v1/journals`
+
+## Live schema workflow
+
+Prefer live Alpaca documentation before generating code that opens accounts, moves money, places orders, or mutates production state:
+
+1. Check `https://docs.alpaca.markets/llms.txt` or `https://docs.alpaca.markets/llms-full.txt` for the current documentation index.
+2. If an `alpaca-docs` MCP server is connected, use it for exact endpoint schemas instead of guessing from examples.
+3. Verify required fields, enum values, pagination, and status transitions against the current Broker API, Trading API, or Market Data API spec.
+
+## Related broker skills
+
+`alpaca-broker-integration`, `alpaca-broker-account-onboarding`, `alpaca-broker-funding-transfers`, `alpaca-broker-trading-orders`, `alpaca-broker-market-data`, `alpaca-broker-sse-events`, `alpaca-broker-reconciliation-idempotency`, `alpaca-broker-rate-limits-resilience`, `alpaca-broker-money-precision`

--- a/skills/broker-api/market-data/SKILL.md
+++ b/skills/broker-api/market-data/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: alpaca-broker-market-data
+description: Pull and stream US stock market data from Alpaca — REST snapshots/bars/trades/quotes, historical bars with timeframes and feeds (IEX vs SIP), the assets master list, market clock & calendar, news, and the real-time WebSocket stream. Use when building charts, quotes, price feeds, or asset metadata on Alpaca in any language.
+---
+
+# Alpaca Market Data API — Stocks (REST + WebSocket)
+
+Real-time and historical US equity data. Unlike the Broker endpoints, market data lives on **its own host with its own auth**, and the real-time feed is **WebSocket**, not SSE.
+
+> Read `alpaca-broker-integration` first. Assets/clock/calendar live on the **Trading API** host; everything else here is the **Market Data API** host.
+
+## Reference
+- Guides: `https://docs.alpaca.markets/docs/historical-stock-data`, `https://docs.alpaca.markets/docs/streaming-market-data`
+- Live schema: `alpaca-docs` MCP → `list-endpoints` title `"Market Data API"`
+
+## 0. Hosts & auth
+
+| Surface | Host |
+|---------|------|
+| Market data REST | `https://data.alpaca.markets` (sandbox `data.sandbox.alpaca.markets`) |
+| Market data WebSocket | `wss://stream.data.alpaca.markets/{version}/{feed}` |
+| Assets / clock / calendar | `https://api.alpaca.markets` (Trading API) — paper: `paper-api.alpaca.markets` |
+
+**Auth:** headers `APCA-API-KEY-ID` / `APCA-API-SECRET-KEY` (Broker partners may use Broker Basic auth in broker context).
+
+## 1. REST endpoints
+
+| Path | Purpose |
+|------|---------|
+| `GET /v2/stocks/snapshots?symbols=…` · `GET /v2/stocks/{symbol}/snapshot` | Snapshot (latest trade/quote + bars) |
+| `GET /v2/stocks/bars?symbols=…` · `GET /v2/stocks/{symbol}/bars` | Historical OHLCV bars |
+| `GET /v2/stocks/bars/latest` · `…/{symbol}/bars/latest` | Latest bar(s) |
+| `GET /v2/stocks/trades[/latest]` · `GET /v2/stocks/quotes[/latest]` | Historical / latest trades & quotes |
+| `GET /v2/stocks/auctions` | Opening/closing auctions |
+| `GET /v2/stocks/meta/conditions/{trade\|quote}` · `/meta/exchanges` | Code lookups |
+| `GET /v1beta1/news?symbols=…` | News (max `limit` 50) |
+| `GET /v1beta1/screener/stocks/most-actives` · `/screener/{stocks\|crypto}/movers` | Screeners |
+| `GET /v2/assets` *(Trading API host)* · `GET /v1/assets` *(Broker API host)* | Asset master / tradability |
+| `GET /v2/clock` · `GET /v2/calendar` *(Trading API host)* | Market hours |
+
+> **Clock/calendar/assets paths are host-dependent — verified live against the sandbox:**
+>
+> | Path | Trading API host (`api.alpaca.markets`) | Broker API host (`broker-api.*`) |
+> |------|:--:|:--:|
+> | `/v1/clock` | — | **200** |
+> | `/v2/clock` | **200** | **200** |
+> | `/v1/calendar` | — | **200** |
+> | `/v2/calendar` | **200** | **404** |
+> | `/v1/assets` | — | **200** |
+> | `/v2/assets` | **200** | **404** |
+>
+> So: on the **Trading/Market-Data API host** use `/v2/clock`, `/v2/calendar`, `/v2/assets`. On the **Broker API host** use **`/v1/clock`**, **`/v1/calendar`**, **`/v1/assets`** (`/v1/clock` and `/v2/clock` both work there; `/v2/calendar` and `/v2/assets` 404). A Broker-API integration hitting `/v1/clock` is **correct**, not stale.
+
+## 2. Bars — params
+
+| Param | Notes |
+|-------|-------|
+| `timeframe` | `[1-59]Min`/`T`, `[1-23]Hour`/`H`, `1Day`/`D`, `1Week`/`W`, `[1,2,3,4,6,12]Month`/`M`. Case-sensitive. e.g. `1Min`, `5Min`, `1Hour`, `1Day` |
+| `start` / `end` | RFC3339 or `YYYY-MM-DD`, inclusive |
+| `limit` | default **1000**, max **10000** — counts data points **across all symbols**, not per symbol |
+| `page_token` | pagination cursor (from `next_page_token`) |
+| `adjustment` | `raw` (default), `split`, `dividend`, `spin-off`, `all` — comma-combinable |
+| `feed` | see §3 |
+| `sort` | `asc` (default) / `desc` |
+| `asof` | `YYYY-MM-DD` for symbol/name-change mapping; `-` skips mapping |
+
+**Pagination lesson:** results are sorted by **symbol, then timestamp**. A multi-symbol request that hits `limit` may return only the first symbol(s) — you must follow `next_page_token` until empty to get them all. Don't assume one page = all symbols.
+
+## 3. Feeds (entitlement matters)
+
+- `iex` — single exchange (~2.5% of volume). **The only feed available without a paid subscription.** Good for dev/testing.
+- `sip` — consolidated, all exchanges (100% volume). **Requires a paid data plan.**
+- `delayed_sip` — SIP delayed 15 min (latest/snapshot endpoints).
+- `otc`, `boats` (Blue Ocean overnight ATS), `overnight` (Alpaca-derived, cheaper).
+
+**Lessons:**
+- **Pick `iex` explicitly** if you're on the free tier — some endpoints default to `sip`, which then 403s without entitlement. (A common surprise: "why is my historical request failing?" → defaulted to SIP.)
+- Without real-time access, `start`/`end` windows **withhold the most recent 15 minutes**.
+- Trade/quote **sizes are in shares** as of 2025-11-03 (were round lots before).
+
+## 4. Object shapes (compact keys)
+
+**Snapshot** per symbol: `latestTrade`, `latestQuote`, `minuteBar`, `dailyBar`, `prevDailyBar`. Multi-symbol response is a map `{ "AAPL": {…} }`.
+
+- **Bar:** `t` time, `o` open, `h` high, `l` low, `c` close, `v` volume, `n` trade count, `vw` VWAP.
+- **Trade:** `t` time, `p` price, `s` size, `x` exchange, `c` conditions, `z` tape, `i` id.
+- **Quote:** `bp`/`bs`/`bx` bid price/size/exchange, `ap`/`as`/`ax` ask price/size/exchange, `c` conditions, `z` tape. (price `0` = no active bid/ask.)
+
+## 5. WebSocket protocol
+
+**URL:** `wss://stream.data.alpaca.markets/{version}/{feed}` — e.g. `v2/iex`, `v2/sip`, `v2/delayed_sip`, `v1beta1/boats`, `v1beta1/overnight`, or `v2/test` (always-on, use symbol `FAKEPACA`).
+
+**Connect flow:**
+1. Connect → `[{"T":"success","msg":"connected"}]`
+2. **Auth within 10s:** `{"action":"auth","key":"…","secret":"…"}` → `[{"T":"success","msg":"authenticated"}]`
+3. Subscribe: `{"action":"subscribe","trades":["AAPL"],"quotes":["AMD"],"bars":["*"]}` → server echoes full subscription state. `*` = all symbols. `unsubscribe` removes.
+
+**Message types** (every message is a **JSON array**; `T` discriminates): `t` trade, `q` quote, `b` minute bar, `d` daily bar, `u` updated bar, `s` trading status (halt/resume), `l` LULD, `c` correction, `x` cancel/error, `i` imbalance; control: `success`, `error`, `subscription`. Subscribing to `trades` auto-adds `corrections` + `cancelErrors`.
+
+**WebSocket lessons:**
+- **One concurrent connection per key** on most plans — a 2nd connection → `{"code":406,"connection limit exceeded"}`. Centralize the stream in **one process** and fan out to your own clients (don't open a socket per user).
+- Authenticate within **10s** or get dropped (`404`).
+- Other error codes: `401` not auth'd, `402` auth failed, `405` symbol limit, `407` slow client, `409` insufficient subscription (feed not entitled), `410` invalid action for feed.
+- Messages are **batched** — always iterate the array; don't assume one frame = one event.
+- Handle **`u` (updated bar)** and **`c`/`x` (corrections/cancels)**: a streamed bar/trade can be revised after the fact.
+
+## 6. Assets, clock, calendar
+
+Use the host-appropriate path (see the table in §1): `/v2/...` on the Trading API host, `/v1/...` on the Broker API host.
+
+- **Assets** (`GET /v2/assets` on Trading host · `GET /v1/assets` and `/v1/assets/{symbol}` on Broker host) — tradability metadata: `tradable`, `fractionable`, `marginable`, `shortable`, `borrow_status` (replaces deprecated `easy_to_borrow`), `status` (`active`/`inactive`), `class` (`us_equity`/`us_option`/`crypto`/`ipo`), `exchange`, `attributes[]` (e.g. `has_options`, `overnight_tradable`). Filter by `status`, `asset_class`, `exchange`. **Cache this** — it changes slowly; query it before trading to confirm `tradable`/`fractionable` (see `alpaca-broker-trading-orders`).
+- **Clock** (`/v2/clock` on Trading host · `/v1/clock` on Broker host) — `is_open`, `next_open`, `next_close`, `timestamp`. Use this to gate market-hours logic instead of hardcoding 9:30–16:00 ET.
+- **Calendar** (`/v2/calendar` on Trading host · `/v1/calendar` on Broker host — note there is no `/v2/calendar` on the Broker host) — per-day `open`/`close` (`HH:MM`), `session_open`/`session_close` (`HHMM`, extended hours), `settlement_date`. **Use the calendar for holidays** — a naive "weekdays only" check runs jobs on market holidays (harmless but wasteful) and miscomputes "previous trading day."
+
+## 7. Caching strategy (cost & rate-limit lesson)
+
+Market data is the highest-volume, highest-cost surface. Production lesson:
+1. **Persist historical bars** in your own store keyed by `(symbol, timeframe, timestamp)` with upsert/skip-duplicate, and serve charts from there — only fetch the gap from Alpaca.
+2. **Cache snapshots/quotes** in a short-TTL cache (TTL tuned to market-open vs closed).
+3. **Run one bulk backfill job** for searchable symbols on a schedule rather than fetching per user request.
+4. Always follow `next_page_token` and watch `X-RateLimit-Remaining` (see `alpaca-broker-rate-limits-resilience`).
+
+**Related skills:** tradability before ordering → `alpaca-broker-trading-orders`; rate limits/pagination → `alpaca-broker-rate-limits-resilience`; the *broker* event stream (SSE, different from this WS) → `alpaca-broker-sse-events`.

--- a/skills/broker-api/market-data/reference.md
+++ b/skills/broker-api/market-data/reference.md
@@ -1,0 +1,20 @@
+# Market Data Reference
+
+Companion to `SKILL.md`. Read the workflow and guardrails there first.
+
+## Primary docs and schemas
+
+- Guides: `https://docs.alpaca.markets/docs/historical-stock-data`, `https://docs.alpaca.markets/docs/streaming-market-data`
+- Live schema: `alpaca-docs` MCP → `list-endpoints` title `"Market Data API"`
+
+## Live schema workflow
+
+Prefer live Alpaca documentation before generating code that opens accounts, moves money, places orders, or mutates production state:
+
+1. Check `https://docs.alpaca.markets/llms.txt` or `https://docs.alpaca.markets/llms-full.txt` for the current documentation index.
+2. If an `alpaca-docs` MCP server is connected, use it for exact endpoint schemas instead of guessing from examples.
+3. Verify required fields, enum values, pagination, and status transitions against the current Broker API, Trading API, or Market Data API spec.
+
+## Related broker skills
+
+`alpaca-broker-integration`, `alpaca-broker-account-onboarding`, `alpaca-broker-funding-transfers`, `alpaca-broker-journals`, `alpaca-broker-trading-orders`, `alpaca-broker-sse-events`, `alpaca-broker-reconciliation-idempotency`, `alpaca-broker-rate-limits-resilience`, `alpaca-broker-money-precision`

--- a/skills/broker-api/money-precision/SKILL.md
+++ b/skills/broker-api/money-precision/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: alpaca-broker-money-precision
+description: Handle money and numeric precision correctly with the Alpaca API — numbers-as-strings on the wire, decimals vs floats, rounding/truncation before sending amounts, fractional-share precision, and safe DB storage. Use when handling monetary amounts, order quantities, or prices in any Alpaca integration in any language.
+---
+
+# Alpaca — Money & Numeric Precision
+
+Financial bugs are silent and expensive. Alpaca's wire format and the realities of decimal arithmetic create a few specific traps. This skill is short, opinionated, and language-agnostic.
+
+> Read `alpaca-broker-integration` first.
+
+## 1. Numbers come as strings — keep them that way
+
+Alpaca returns prices, quantities, notional, and money amounts as **JSON strings** (`"100.50"`, `"1.5"`, `"190.2345"`), and accepts them as strings on the way in. This is deliberate: it avoids the precision loss of JSON's binary floats.
+
+**Rule:** parse string money fields into a **decimal type**, never a binary `float`/`double`. Serialize back to a string. Don't let a number ever live as an IEEE-754 float in the money path.
+
+| Language | Use | Avoid |
+|----------|-----|-------|
+| Python | `decimal.Decimal("100.50")` | `float("100.50")` |
+| TypeScript/JS | a decimal lib (`decimal.js`/`big.js`) or string arithmetic | `Number(...)`, `parseFloat` |
+| Go | `shopspring/decimal` | `float64` for accumulation |
+| Java/Kotlin | `java.math.BigDecimal` | `double` |
+
+> Real-world caveat: not every Alpaca endpoint is consistent — some market-data numeric fields come as JSON numbers (e.g. bar OHLC). Prices for display/analytics can tolerate floats; **money you move or store must not**. Know which field you're touching.
+
+## 2. Round/truncate before sending — and know the direction
+
+Alpaca generally accepts **2 decimal places for cash** amounts and up to **9 for fractional share `qty`/`notional`**. If you send more precision than allowed, you risk rejection or silent rounding on their side.
+
+**Rule:** explicitly round/truncate to the target precision *before* the API call, using a deliberate rounding mode.
+
+- For **money you're moving out / charging**, **truncate (round down)** to 2 dp so you never move more than intended. (e.g. `floor(amount * 100) / 100`.)
+- Pick the rounding mode consciously (`ROUND_DOWN` vs `ROUND_HALF_UP`) — don't inherit whatever the default float formatting does.
+- Re-round after every arithmetic step that could reintroduce precision (e.g. computing `amount * percentage` for a split allocation), not just at the end.
+
+```
+# splitting a deposit across holdings — round each slice down, track remainder
+slice = truncate(total * (pct / 100), 2)
+```
+
+## 3. Fractional shares
+
+- `qty` and `notional` support up to **9 decimal places**.
+- `qty` XOR `notional` — never both (see `alpaca-broker-trading-orders`).
+- Don't reconstruct `qty` from `notional / price` and send it — pass `notional` and let Alpaca compute the fill. Round-tripping through a price you fetched introduces drift.
+
+## 4. Storage
+
+- Store money in your DB as **fixed-point decimal**, not float. A practical pattern is generous precision/scale, e.g. `DECIMAL(20, 8)` — wide enough for multi-currency and fractional, with headroom beyond Alpaca's 2-dp cash so you never lose data you received.
+- **Store what Alpaca sent verbatim** alongside any converted/derived values. If you truncate to 2 dp for the API call but received more precision back, keep both — it makes reconciliation and audits possible.
+- Keep an explicit **currency** column; Alpaca is multi-currency on some rails (funding wallet) even though most is USD.
+
+## 5. Multi-currency notes
+
+- Most Broker/trading flows are USD; journals default to USD.
+- The **funding wallet** rail supports many currencies (`USD`, `EUR`, `JPY`, …) and carries FX fees. When you touch it, never assume USD — read and store the `currency`, and treat FX amounts as decimals end-to-end.
+
+## 6. Checklist
+
+- [ ] Money fields parsed from strings into a **decimal** type; serialized back to strings.
+- [ ] **No binary floats** anywhere in the move-money path.
+- [ ] Amounts rounded/truncated to the allowed precision **before** the call, with an intentional rounding mode (round *down* for outgoing money).
+- [ ] Re-round after each intermediate computation.
+- [ ] DB columns are fixed-point decimal with headroom; raw Alpaca values stored verbatim.
+- [ ] Explicit currency tracked.
+
+**Related skills:** order qty/notional rules → `alpaca-broker-trading-orders`; journal/transfer amounts → `alpaca-broker-journals`, `alpaca-broker-funding-transfers`; reconciling stored vs Alpaca values → `alpaca-broker-reconciliation-idempotency`.

--- a/skills/broker-api/money-precision/reference.md
+++ b/skills/broker-api/money-precision/reference.md
@@ -1,0 +1,20 @@
+# Money & Numeric Precision Reference
+
+Companion to `SKILL.md`. Read the workflow and guardrails there first.
+
+## Primary docs and schemas
+
+- Docs home: `https://docs.alpaca.markets/`
+- Prefer endpoint schemas for exact numeric field formats before moving money or placing orders.
+
+## Live schema workflow
+
+Prefer live Alpaca documentation before generating code that opens accounts, moves money, places orders, or mutates production state:
+
+1. Check `https://docs.alpaca.markets/llms.txt` or `https://docs.alpaca.markets/llms-full.txt` for the current documentation index.
+2. If an `alpaca-docs` MCP server is connected, use it for exact endpoint schemas instead of guessing from examples.
+3. Verify required fields, enum values, pagination, and status transitions against the current Broker API, Trading API, or Market Data API spec.
+
+## Related broker skills
+
+`alpaca-broker-integration`, `alpaca-broker-account-onboarding`, `alpaca-broker-funding-transfers`, `alpaca-broker-journals`, `alpaca-broker-trading-orders`, `alpaca-broker-market-data`, `alpaca-broker-sse-events`, `alpaca-broker-reconciliation-idempotency`, `alpaca-broker-rate-limits-resilience`

--- a/skills/broker-api/rate-limits-resilience/SKILL.md
+++ b/skills/broker-api/rate-limits-resilience/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: alpaca-broker-rate-limits-resilience
+description: Make Alpaca API clients resilient — rate-limit header handling, HTTP 429 backoff, exponential retry, bounded concurrency/worker pools, pagination loops, batch sizing, and timeouts. Use when building robust REST clients, bulk/cron jobs, or reconciliation sweeps against Alpaca in any language.
+---
+
+# Alpaca — Rate Limits & Resilience
+
+Alpaca's APIs are rate-limited and occasionally flaky under load. Any client that does more than a handful of calls — especially bulk jobs, backfills, and reconciliation sweeps — needs disciplined retry, backoff, and concurrency control. These patterns are transport-level and apply in any language.
+
+> Read `alpaca-broker-integration` first.
+
+## 1. Rate-limit headers — read them on every response
+
+Alpaca returns standard headers:
+
+| Header | Meaning |
+|--------|---------|
+| `X-RateLimit-Limit` | requests allowed in the window |
+| `X-RateLimit-Remaining` | requests left in the current window |
+| `X-RateLimit-Reset` | **unix timestamp (seconds)** when the window resets |
+
+**Parse them on every response, not just on errors.** Two uses:
+- **Proactive:** when `Remaining` drops below a threshold (e.g. ≤ 50), log a warning and/or slow down — you're about to get throttled.
+- **Reactive:** on `429`, use `Reset` to wait exactly until the window opens.
+
+> Limits vary by endpoint and plan; market-data limits differ from broker limits. Don't hardcode a number — react to the headers.
+
+## 2. The retry loop (pseudocode)
+
+```
+MAX_ATTEMPTS = 10
+INITIAL_DELAY_MS = 1000
+
+for attempt in 1..MAX_ATTEMPTS:
+    res = http(request)                      # with a sane timeout (see §5)
+    remaining, reset_at = parse_rate_headers(res.headers)
+    if remaining <= 50: log_warn("approaching rate limit", reset_at)
+
+    if res.status == 429:
+        # wait until the window resets, plus a small buffer
+        wait = (reset_at - now()) if reset_at else INITIAL_DELAY_MS * 2^(attempt-1)
+        sleep(max(0, wait) + 1000)           # +1s buffer past reset
+        continue
+
+    if res.status in (500, 502, 503, 504) or network_error:
+        sleep(INITIAL_DELAY_MS * 2^(attempt-1))   # exponential backoff
+        continue
+
+    return res                                # success or non-retryable 4xx
+raise last_error
+```
+
+Key points:
+- **On `429`, wait until `X-RateLimit-Reset` + a ~1s buffer** — don't blindly exponential-backoff when the API told you exactly when to retry.
+- **Exponential backoff** (`base * 2^(attempt-1)`) for network errors and 5xx. With base 1s and 10 attempts the tail is minutes — fine for background jobs, too slow for user-facing calls (use fewer attempts there).
+- **Don't retry non-retryable 4xx** (`400`/`403`/`422`) — those won't fix themselves; surface them.
+- Optionally add **jitter** to backoff to avoid thundering-herd when many workers retry together.
+
+## 3. Bounded concurrency
+
+Parallelism speeds bulk jobs but is the fastest way to hit limits. Use a **fixed worker pool**, not unbounded fan-out.
+
+- Start small (e.g. **5–8 concurrent requests**) and tune against the rate-limit headers. A real lesson from production: a pool was *reduced* from 10 → 5 to ease both Alpaca and downstream-DB load.
+- Cache per-entity reads **within a run** (e.g. an account's buying power, or a per-account transfer list) so you don't refetch the same thing across items in a batch.
+- For per-item throttling, a small fixed sleep between calls (e.g. 100ms) is a crude-but-effective floor when you can't easily coordinate a pool.
+
+## 4. Pagination loops
+
+List endpoints page forward with a token — never assume one response is complete.
+
+- **Activities** (`/v1/accounts/activities`): page via the `X-Next-Page-Token` response header; loop until it's empty. Use `page_size` (≤100) and a `direction`.
+- **Market-data bars** (`/v2/stocks/bars`): page via `next_page_token` in the body → pass back as `page_token`. Remember `limit` counts across all symbols and results sort by symbol-then-time, so **a single page may contain only the first symbol(s)** — keep paging.
+- Wrap each page fetch in the retry loop from §2.
+
+```
+token = null
+loop:
+    page = fetch(url + (token ? "&page_token="+token : ""))   # via retry loop
+    accumulate(page.items)
+    token = page.next_token            # header or body, per endpoint
+    if not token: break
+```
+
+## 5. Timeouts & batch sizing
+
+- **Always set an HTTP timeout** (e.g. 15–30s). A hung connection without a timeout stalls a whole worker pool. (SSE streams are the exception — they're meant to stay open; see `alpaca-broker-sse-events`.)
+- Use a **shared HTTP client / connection pool** rather than constructing one per request, so keep-alive and connection reuse work.
+- When writing reconciliation results to your own store, **chunk bulk inserts** (e.g. 500 rows per statement) to stay under DB statement-size limits and keep transactions reasonable.
+
+## 6. Resilience checklist for a bulk/cron job
+
+- [ ] Rate-limit headers parsed every response; proactive warn near the limit.
+- [ ] `429` → wait until `X-RateLimit-Reset` + buffer.
+- [ ] Exponential backoff (+ jitter) for 5xx/network; capped attempts.
+- [ ] Non-retryable 4xx surfaced, not retried.
+- [ ] Bounded worker pool; per-run caching of repeated reads.
+- [ ] Pagination loop until the token is empty.
+- [ ] HTTP timeout on every call; shared client.
+- [ ] Bulk DB writes chunked and idempotent (upsert) — see `alpaca-broker-reconciliation-idempotency`.
+- [ ] Structured logging with a trace/correlation ID per item for debugging partial failures.
+
+**Related skills:** safe re-runs of jobs → `alpaca-broker-reconciliation-idempotency`; the heal/poll jobs that use these patterns → `alpaca-broker-reconciliation-idempotency`; market-data pagination specifics → `alpaca-broker-market-data`.

--- a/skills/broker-api/rate-limits-resilience/reference.md
+++ b/skills/broker-api/rate-limits-resilience/reference.md
@@ -1,0 +1,20 @@
+# Rate Limits & Resilience Reference
+
+Companion to `SKILL.md`. Read the workflow and guardrails there first.
+
+## Primary docs and schemas
+
+- Docs home: `https://docs.alpaca.markets/`
+- Inspect `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers from live responses.
+
+## Live schema workflow
+
+Prefer live Alpaca documentation before generating code that opens accounts, moves money, places orders, or mutates production state:
+
+1. Check `https://docs.alpaca.markets/llms.txt` or `https://docs.alpaca.markets/llms-full.txt` for the current documentation index.
+2. If an `alpaca-docs` MCP server is connected, use it for exact endpoint schemas instead of guessing from examples.
+3. Verify required fields, enum values, pagination, and status transitions against the current Broker API, Trading API, or Market Data API spec.
+
+## Related broker skills
+
+`alpaca-broker-integration`, `alpaca-broker-account-onboarding`, `alpaca-broker-funding-transfers`, `alpaca-broker-journals`, `alpaca-broker-trading-orders`, `alpaca-broker-market-data`, `alpaca-broker-sse-events`, `alpaca-broker-reconciliation-idempotency`, `alpaca-broker-money-precision`

--- a/skills/broker-api/reconciliation-idempotency/SKILL.md
+++ b/skills/broker-api/reconciliation-idempotency/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: alpaca-broker-reconciliation-idempotency
+description: Keep local state correct against the Alpaca Broker API — idempotency keys, ID-keyed upserts, event snapshotting and dedup, polling rails that have no events, nightly reconciliation/heal jobs, status state-machine mapping, and handling eventual consistency and corrections. Use when designing the data-correctness layer of any Alpaca integration in any language.
+---
+
+# Alpaca — Reconciliation & Idempotency
+
+This is the skill that separates a demo from production. Alpaca is an **asynchronous, eventually-consistent** system: writes settle later, events can be missed or replayed, some rails emit no events at all, and "executed" can still be reversed. Your job is to make your local database a faithful, self-healing mirror of Alpaca's state.
+
+> Read `alpaca-broker-integration`, `alpaca-broker-sse-events`, and the relevant domain skills first. This skill is the architecture that ties them together.
+
+## The core principle
+
+> **Treat Alpaca as the source of truth and your DB as a cache that must converge to it.** Every write is a request, not a fact. Every event is a hint, not a guarantee. Correctness comes from *idempotent* processing plus a *reconciliation* loop — never from assuming any single call or event succeeded exactly once.
+
+## 1. Three layers of defense
+
+```
+Layer 1 — Idempotent writes      : never create a duplicate when you retry
+Layer 2 — Idempotent event intake: never double-process a replayed/duplicate event
+Layer 3 — Reconciliation sweep   : re-pull authoritative state and fix any drift
+```
+
+You need all three. Layer 1+2 keep you correct in the happy/retry case; Layer 3 catches everything that still slips through (downtime, bugs, missing events, corrections).
+
+## 2. Layer 1 — Idempotent writes
+
+Every money/order write must be safe to retry, because you can't tell a timeout apart from a success.
+
+- **Orders:** set your own `client_order_id` (≤128 chars) derived from your transaction ID. On a lost response, look the order up via `orders:by_client_order_id` before retrying.
+- **Journals:** send an `Idempotency-Key` header. Same key + same body returns the original journal; same key + different body → `422`. (See `alpaca-broker-journals`.)
+- **Local-first ordering:** write your intent row (with a generated key) *before* the network call, so a crash mid-call leaves a record you can reconcile — never an orphaned Alpaca object you can't find.
+- **Persist the returned Alpaca ID immediately** (`account_id`, `order_id`, `journal_id`, `transfer_id`). It is your only correlation key for events and reconciliation.
+
+## 3. Layer 2 — Idempotent event intake
+
+Events are **at-least-once**: replay cursors, reconnects, and corrections all cause the same event to arrive more than once.
+
+- **Snapshot-first, keyed on `event_id`.** Insert the raw event with upsert / skip-on-duplicate on `event_id` (a ULID). A duplicate becomes a no-op. This single unique constraint is your dedup boundary.
+- **Key business records on the Alpaca ID**, not on a local autoincrement, with upsert semantics.
+- **Guard transitions by current status.** Before acting, check the record isn't already terminal — so a duplicate "executed"/"filled" doesn't re-fire a payout or notification.
+- **Lock the row** while mutating (`SELECT … FOR UPDATE` or your engine's equivalent) so concurrent events for one record serialize.
+- **Advance the cursor only after success** (at-least-once, made safe by the above).
+
+## 4. Layer 3 — Reconciliation / heal jobs
+
+A scheduled job that re-pulls authoritative state from Alpaca and upserts it locally. This is what makes the system **self-healing**.
+
+**Canonical nightly heal (lesson):**
+1. For each active account, page through **trade activities** and **non-trade activities** (`GET /v1/accounts/activities`, paginated) for the last *N* days (e.g. 3) — a moving window that re-covers recent days so anything missed by SSE gets backfilled.
+2. Page through **journals** (`GET /v1/journals`) and **transfers** for the same window.
+3. **Upsert** each into your tables keyed on the Alpaca ID (insert-or-update). Re-running is safe and converges.
+4. Bound concurrency (a small worker pool) and respect rate limits (`alpaca-broker-rate-limits-resilience`).
+
+Why a *window* and not just "since last run": it absorbs corrections, late settlements, and any events dropped during a deploy — without rescanning all history every night.
+
+## 5. Polling the rails that have no events
+
+Not everything emits SSE. Where there's no event, you **must poll**.
+
+- **Funding-wallet per-transfer status** (v1beta) is not pushed — poll `GET /v1beta/.../funding_wallet/transfers/{id}` on a schedule.
+- Stagger pollers (e.g. one rail at `:00`, another at `:30`) to spread API load.
+- **Only poll records in a non-terminal state.** Filter your query to `status IN (pending, processing, …)`; once a record reaches a terminal status, drop it from the polling set. This bounds the work and prevents re-notifying.
+- **Gotcha — no GET-by-id on classic wire transfers:** you must `GET /v1/accounts/{id}/transfers?direction=OUTGOING` (a *list*) and match the ID client-side; cache the list per account within a run.
+
+**Lesson:** polling implies latency. Document the expected lag (e.g. "withdrawal status updates within ~1h") so product/support set the right expectations.
+
+## 6. Status state-machine mapping
+
+Alpaca exposes several status enums (account, order, journal, transfer, funding-wallet) — each with its own vocabulary. Don't scatter raw Alpaca strings through your app.
+
+- **Define one explicit mapping table** per domain from Alpaca status → your internal status (e.g. `executed`/`COMPLETE` → `COMPLETED`; `rejected`/`canceled`/`returned`/`failed` → `CANCELLED`).
+- **Handle unknown statuses gracefully** — log and skip, never crash. Alpaca adds values (and has shipped bad ones — e.g. a stray `TRD` activity type that consumers had to filter out).
+- **Know which states are terminal** (they differ per enum) so you stop polling/processing them.
+
+## 7. Eventual-consistency hazards to design for
+
+- **`executed`/`COMPLETE` is not always final** — journals can be reversed by cashiering; transfers can be `RETURNED` after appearing done. Keep reconciling past the "happy" terminal state for a window.
+- **Corrections create new IDs.** A journal `correct` cancels the original and issues a *new* journal ID carrying the real funds. Reconciliation keyed on event snapshots + Alpaca IDs handles this; logic that mutates the original record in place does not.
+- **`200` means accepted, not settled.** Never confirm money moved to a user off the create response — confirm off the terminal event/poll.
+- **Out-of-order & duplicate events** are normal (see `alpaca-broker-sse-events` §5). Idempotency absorbs them.
+
+## 8. Anti-patterns (seen in the wild)
+
+- ❌ Reconnecting an SSE stream **without** a `since_id` cursor → silently drops every event during the gap. (Fix: persist + replay the cursor.)
+- ❌ Treating an SSE stream as your *only* source → no backstop for missed events. (Fix: add the heal job.)
+- ❌ Blind retry of a journal/order without an idempotency key → double money movement.
+- ❌ Acting on `executed` as irreversible → broken books when a reversal/correction lands.
+- ❌ Dedup keyed on a `confirmed` set instead of a `seen` set → judge/reject churn re-processes forever. Dedup on *everything seen*, key on the Alpaca/event ID.
+
+## 9. Putting it together
+
+```
+WRITE:   local intent row (idempotency key) → Alpaca call → store Alpaca ID
+LIVE:    SSE consumer (cursor-replay, snapshot-keyed dedup, status-guarded upsert)
+POLL:    schedulers for rails with no events (non-terminal records only)
+HEAL:    nightly window re-pull of activities/journals/transfers → upsert
+MAP:     Alpaca status → internal status, terminal-aware, unknown-tolerant
+```
+
+**Related skills:** event consumption mechanics → `alpaca-broker-sse-events`; idempotency keys per domain → `alpaca-broker-journals`, `alpaca-broker-trading-orders`; polling rails → `alpaca-broker-funding-transfers`; backoff & rate limits in heal jobs → `alpaca-broker-rate-limits-resilience`.

--- a/skills/broker-api/reconciliation-idempotency/reference.md
+++ b/skills/broker-api/reconciliation-idempotency/reference.md
@@ -1,0 +1,20 @@
+# Reconciliation & Idempotency Reference
+
+Companion to `SKILL.md`. Read the workflow and guardrails there first.
+
+## Primary docs and schemas
+
+- Docs home: `https://docs.alpaca.markets/`
+- Confirm domain-specific status enums in live endpoint schemas before implementing state machines.
+
+## Live schema workflow
+
+Prefer live Alpaca documentation before generating code that opens accounts, moves money, places orders, or mutates production state:
+
+1. Check `https://docs.alpaca.markets/llms.txt` or `https://docs.alpaca.markets/llms-full.txt` for the current documentation index.
+2. If an `alpaca-docs` MCP server is connected, use it for exact endpoint schemas instead of guessing from examples.
+3. Verify required fields, enum values, pagination, and status transitions against the current Broker API, Trading API, or Market Data API spec.
+
+## Related broker skills
+
+`alpaca-broker-integration`, `alpaca-broker-account-onboarding`, `alpaca-broker-funding-transfers`, `alpaca-broker-journals`, `alpaca-broker-trading-orders`, `alpaca-broker-market-data`, `alpaca-broker-sse-events`, `alpaca-broker-rate-limits-resilience`, `alpaca-broker-money-precision`

--- a/skills/broker-api/sse-events/SKILL.md
+++ b/skills/broker-api/sse-events/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: alpaca-broker-sse-events
+description: Consume Alpaca Broker API real-time event streams over Server-Sent Events (SSE) — account status, journal, transfer/funding, trade, and non-trade-activity events — reliably. Covers connection, auth, replay cursors (since/since_id), heartbeats, reconnection/backoff, ordering, and idempotent processing. Use when building an event consumer for Alpaca lifecycle events in any language.
+---
+
+# Alpaca Broker API — Real-Time Events (SSE)
+
+Alpaca pushes brokerage lifecycle events over **Server-Sent Events**: a long-lived HTTP GET that streams `text/event-stream`. This is *not* the market-data WebSocket (`alpaca-broker-market-data`) — different transport, different auth, different reliability model.
+
+> Read `alpaca-broker-integration` first. SSE uses the **Broker API host + HTTP Basic auth** (same credential as Broker REST).
+
+## Reference
+- Guide: `https://docs.alpaca.markets/docs/sse-events`
+- Live: `alpaca-docs` MCP → `search` "SSE Events", then `fetch us/sse-events`
+
+## 1. Why SSE (and why it's simpler than it looks)
+
+SSE is plain HTTP. You don't need a special client: open a GET, keep the connection open, and read the body line-by-line. Each event is a `data:` line containing a JSON object. It is **replayable** — you can ask for events from a point in the past and seamlessly catch up to live, which makes it far better than naive polling for lifecycle state.
+
+## 2. Event streams
+
+| Stream | Path | Carries |
+|--------|------|---------|
+| Account status | `GET /v1/events/accounts/status` | Account-property changes: `status`/`crypto_status` (`SUBMITTED`→`ACTIVE`, `ACTION_REQUIRED`, `REJECTED`), plus `kyc_results`, `account_blocked`, `trading_blocked`, `cash_interest`, `options` |
+| Journal status | `GET /v2/events/journals/status` | JNLC/JNLS lifecycle (`queued`→`executed`, `correct`…) |
+| Funding/transfer status | `GET /v2/events/funding/status` | Unified: `Transfer`, `BankRelationship`, `WireBank`, `FundingWallet` entities (switch on `entity_type`) |
+| Trade updates | `GET /v2/events/trades` | Order events in the `event` field: `new`, `fill`, `partial_fill`, `canceled`, `rejected`, `held`, `trade_bust`, `trade_correct`… (richer than order `status`) |
+| Non-trade activities | `GET /v1/events/nta` | Dividends, interest, fees, splits, ACATs, cash disbursements. `entry_type` e.g. `JNLC`/`FEE`/`INT`/`DIVNRA`/`CSD`; `status` ∈ `executed`/`correct`/`canceled` |
+
+> **Paths & versions are NOT uniform — verify each.** This is exactly the kind of cross-stream inconsistency Alpaca's docs under-communicate:
+> - **`/v2`** streams (trades, journals/status, funding/status) use a **ULID** `event_id` directly; `/v1/events/trades` and `/v1/events/journals/status` are *legacy* (existing partners only — migrate to v2). `/v2/events/trades` was previously `/v2beta1`, now redirected.
+> - **`/v1`** streams (accounts/status, nta) are **current, not deprecated** — there is no v2 yet. Each event carries **both** an integer `event_id` *and* a ULID `event_ulid`.
+>
+> Every event carries `at` (timestamp), `account_id`, and `status_from`/`status_to` (account/journal/funding) or `event`+`order` (trades).
+
+## 3. Connection
+
+```
+GET /v2/events/journals/status?since_id=<last-ulid-you-saw> HTTP/1.1
+Host: broker-api.alpaca.markets
+Authorization: Basic <base64(key:secret)>
+Accept: text/event-stream
+```
+
+Read the response stream and parse `data: {…}` frames as they arrive. In most languages an off-the-shelf EventSource/SSE client works — **just make sure it lets you set the `Authorization` header** on the initial request (the browser `EventSource` API famously does *not*; use a server-side SSE library instead).
+
+## 4. Replay cursors — the feature that prevents data loss
+
+Every stream supports point-in-time replay:
+
+| Param | Meaning |
+|-------|---------|
+| `since` / `until` | Date or RFC3339 timestamps. **URL-encode `+`** in offsets as `%2B`. |
+| `since_id` / `until_id` | ID cursors. On **v2** streams the ID *is* a ULID. On **v1** streams it's the **integer** `event_id`. |
+| `since_ulid` / `until_ulid` | **v1 streams only** (accounts, nta) — ULID-based cursors, since v1 events carry both an int `event_id` and a `event_ulid`. |
+
+Rules: `since` is required if `until` is set; `since_id` required if `until_id` set (same for `since_ulid`/`until_ulid`); you **can't mix** `since`, `since_id`, and `since_ulid`. **Without any since cursor, no history is returned** — you only get live pushes from now on. Reaching the `until` bound ends the stream with a `200`.
+
+**This is the single most important reliability lesson:** persist the ID of the last event you *successfully processed*. On every (re)connect, pass it as your since cursor (`since_id` on v2; `since_ulid` or `since_id` on v1) so Alpaca replays anything you missed during the gap. A consumer that reconnects **without** a cursor silently drops every event that occurred while it was down.
+
+## 5. Ordering caveat
+
+Within a millisecond, ULIDs contain a random component, so two events in the same millisecond can sort either way. Alpaca's own guidance: **for reconciliation, restart the stream from a `since` a few minutes before your last event** and rely on idempotent processing to absorb the overlap. Don't assume strict total ordering — assume *approximate* ordering plus dedup.
+
+## 6. Reliability patterns (hard-won)
+
+SSE connections drop — networks, load balancers, deploys, and Alpaca-side resets all happen. A production consumer needs:
+
+1. **Heartbeat / silence detection.** SSE has no application heartbeat by default. Track `lastMessageAt` on every frame; if the stream is silent past a threshold (e.g. 5 min), proactively tear down and reconnect — a dead socket often looks "open."
+2. **Reconnect with exponential backoff + cap.** On error/close, reconnect after a delay that doubles up to a ceiling (e.g. start 1s, cap 60s). Reset the delay on a successful connect.
+3. **A single-reconnect guard.** Use a flag so an error storm doesn't spawn many concurrent reconnect attempts racing each other.
+4. **Always reconnect with `since_id`** = last processed event (see §4).
+5. **Process idempotently** (see §7) — overlap from replay is expected, not exceptional.
+6. **Don't let a side-effect failure kill the stream.** Wrap per-event processing in try/catch; log and continue. One bad event (or a downstream outage) must not stop you consuming the rest.
+
+> Note: OpenAPI can't fully model SSE, so **generated API clients often hang** on these endpoints (waiting for a response that never ends). Use a real streaming HTTP/SSE client, not a codegen'd one.
+
+## 7. Idempotent processing pipeline
+
+The robust shape for each event:
+
+```
+parse → persist a raw event snapshot (keyed on event_id, skip-if-exists)
+      → match the local record by Alpaca ID (account_id / journal_id / order_id / transfer_id)
+      → update local state under a row lock / guarded by current status
+      → fire side effects (notifications, downstream transfers)
+      → advance the stored cursor to this event_id
+```
+
+- **Snapshot-first, keyed on `event_id`.** Insert the raw event with an upsert/skip-duplicate on `event_id`. A duplicate (from replay or an at-least-once redelivery) is then a no-op. This is your dedup boundary.
+- **Lock the target row** (`SELECT … FOR UPDATE` or equivalent) when mutating a transfer/order so two events for the same record can't race.
+- **Guard transitions by current status** — e.g. only act on a transfer that isn't already in a terminal state, so a late/duplicate "executed" doesn't re-trigger a payout.
+- **Advance the cursor only after successful processing**, so a crash mid-event replays it rather than skipping it (at-least-once, which idempotency makes safe).
+
+## 8. Per-stream notes
+
+- **Account status:** drive onboarding UI and "enable trading" off `status_to == ACTIVE`. Reject sandbox/paper account IDs in live handlers.
+- **Trade updates:** `new`/`accepted`/`pending_new` are pre-fill; update local order state on `fill`/`partial_fill`/`canceled`/`rejected`. Invalidate any cached portfolio/holdings on fills.
+- **Journals:** remember `executed` isn't final and `correct` spawns a *new* journal ID (see `alpaca-broker-journals`). Idempotency + ID-keyed snapshots absorb both.
+- **Funding/transfer:** unified stream across 4 entity types; switch on `entity_type`. Funding-wallet *per-transfer* status may still need polling (`alpaca-broker-funding-transfers`).
+- **NTA:** dividends/fees/interest/corporate-actions — persist as activity snapshots; these feed balance/portfolio reconciliation.
+
+## 9. SSE is necessary but not sufficient
+
+Even a perfect consumer can miss events (extended downtime beyond retention, a bug, an un-handled type). **Always pair SSE with a periodic reconciliation/heal pass** that re-pulls authoritative state (activities, journals, transfers) from Alpaca and upserts it. SSE is for low latency; reconciliation is for correctness. See `alpaca-broker-reconciliation-idempotency`.
+
+**Related skills:** correctness backstop → `alpaca-broker-reconciliation-idempotency`; dedup/idempotency mechanics → `alpaca-broker-reconciliation-idempotency`; backoff details → `alpaca-broker-rate-limits-resilience`; market-data streaming (WS, not SSE) → `alpaca-broker-market-data`.

--- a/skills/broker-api/sse-events/reference.md
+++ b/skills/broker-api/sse-events/reference.md
@@ -1,0 +1,20 @@
+# Broker SSE Events Reference
+
+Companion to `SKILL.md`. Read the workflow and guardrails there first.
+
+## Primary docs and schemas
+
+- Guide: `https://docs.alpaca.markets/docs/sse-events`
+- Live: `alpaca-docs` MCP → `search` "SSE Events", then `fetch us/sse-events`
+
+## Live schema workflow
+
+Prefer live Alpaca documentation before generating code that opens accounts, moves money, places orders, or mutates production state:
+
+1. Check `https://docs.alpaca.markets/llms.txt` or `https://docs.alpaca.markets/llms-full.txt` for the current documentation index.
+2. If an `alpaca-docs` MCP server is connected, use it for exact endpoint schemas instead of guessing from examples.
+3. Verify required fields, enum values, pagination, and status transitions against the current Broker API, Trading API, or Market Data API spec.
+
+## Related broker skills
+
+`alpaca-broker-integration`, `alpaca-broker-account-onboarding`, `alpaca-broker-funding-transfers`, `alpaca-broker-journals`, `alpaca-broker-trading-orders`, `alpaca-broker-market-data`, `alpaca-broker-reconciliation-idempotency`, `alpaca-broker-rate-limits-resilience`, `alpaca-broker-money-precision`

--- a/skills/broker-api/trading-orders/SKILL.md
+++ b/skills/broker-api/trading-orders/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: alpaca-broker-trading-orders
+description: Place and manage orders on behalf of accounts via the Alpaca Broker API — order creation (qty vs notional, fractional shares, order types/TIF/classes), order status lifecycle, replace/cancel, positions, and trading-account buying power. Use when building trading, recurring-invest, or portfolio flows on Alpaca in any language.
+---
+
+# Alpaca Broker API — Trading on Behalf of Accounts
+
+Place, modify, cancel, and track orders for an end-user account, and read positions & buying power. The defining feature of Broker API trading: **`account_id` is in the path** — you act *for* a user account, not your own.
+
+> Read `alpaca-broker-integration` first. Broker API + HTTP Basic auth. (The standalone Trading API uses `/v2/orders` with no account in the path; everything else here transfers.)
+
+## Reference
+- Guides: `https://docs.alpaca.markets/docs/orders-at-alpaca`, `https://docs.alpaca.markets/docs/fractional-trading`
+- API ref: `https://docs.alpaca.markets/reference/postorder`
+- Live schema: `alpaca-docs` MCP → `get-endpoint` title `"Broker API"` path `/v1/trading/accounts/{account_id}/orders`
+
+## 1. Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/v1/trading/accounts/{id}/orders` | Create order |
+| GET | `/v1/trading/accounts/{id}/orders` | List orders (filter by `status`, `symbols`, `after`…) |
+| GET | `/v1/trading/accounts/{id}/orders/{order_id}` | Get order by ID |
+| GET | `/v1/trading/accounts/{id}/orders:by_client_order_id?client_order_id=…` | Get by your client ID |
+| PATCH | `/v1/trading/accounts/{id}/orders/{order_id}` | Replace (modify) order |
+| DELETE | `/v1/trading/accounts/{id}/orders/{order_id}` | Cancel one order (204) |
+| DELETE | `/v1/trading/accounts/{id}/orders` | Cancel all (207 Multi-Status) |
+| POST | `/v1/trading/accounts/{id}/orders/estimation` | Cost-estimate an order |
+| GET / DELETE | `/v1/trading/accounts/{id}/positions[/{symbol_or_asset_id}]` | List / close positions |
+| GET | `/v1/trading/accounts/{id}/account` | Trading-account details (buying power etc.) |
+
+## 2. Create-order request
+
+Schema-required: `type` and `time_in_force`. Conditionally required: `symbol`, `side`, and exactly one of `qty`/`notional`.
+
+```json
+// notional market buy (dollar-based, fractional)
+{ "symbol": "AAPL", "notional": "25.00", "side": "buy", "type": "market", "time_in_force": "day",
+  "client_order_id": "your-own-uuid" }
+
+// limit qty sell
+{ "symbol": "AAPL", "qty": "3", "side": "sell", "type": "limit", "limit_price": "190.00", "time_in_force": "gtc" }
+```
+
+| Field | Values / notes |
+|-------|----------------|
+| `symbol` | required (except `mleg` multi-leg options) |
+| `qty` | decimal **string**, up to 9 dp. Fractional only for `market`+`day` |
+| `notional` | decimal **string**, up to 9 dp. **Mutually exclusive with `qty`** |
+| `side` | `buy`, `sell` (plus advanced: `sell_short`, …) |
+| `type` | `market`, `limit`, `stop`, `stop_limit`, `trailing_stop` |
+| `time_in_force` | `day`, `gtc`, `opg`, `cls`, `ioc`, `fok` |
+| `limit_price` / `stop_price` | required for limit/stop variants |
+| `trail_price` / `trail_percent` | one required for `trailing_stop` |
+| `extended_hours` | bool; only with `type=limit` and TIF `day`/`gtc` |
+| `client_order_id` | ≤128 chars; **your idempotency key** (auto-generated if omitted) |
+| `order_class` | `simple` (default), `bracket`, `oco`, `oto`, `mleg` |
+| `take_profit` / `stop_loss` | `{limit_price}` / `{stop_price, limit_price?}` for bracket/oco/oto |
+| `position_intent` | `buy_to_open`, `sell_to_close`, … |
+
+**qty XOR notional (verbatim rule):** pass one or the other — supplying both → `400`. In the response, whichever you didn't use comes back `null`.
+
+## 3. Fractional / notional rules
+
+- **On by default** for all accounts (live + paper).
+- Asset must have **`fractionable: true`** (check the Assets API — see `alpaca-broker-market-data`), else `requested asset is not fractionable`.
+- **TIF must be `day`** for fractional/notional.
+- **Notional** is limited to `market` and `limit` (day); only `limit` for extended hours. Fractional `qty` additionally allows `stop`/`stop_limit` per the guide.
+- **No shorting fractional** — all fractional sells are marked long.
+- Precision: up to **9 decimal places** for both `qty` and `notional`.
+
+## 4. Order status lifecycle
+
+`OrderStatus` (the order object's `status`): `new`, `partially_filled`, `filled`, `done_for_day`, `canceled`, `expired`, `replaced`, `pending_cancel`, `pending_replace`, `accepted`, `pending_new`, `accepted_for_bidding`, `stopped`, `rejected`, `suspended`, `calculated`.
+
+> **Order `status` ≠ trade-event `event`.** The order object's `status` is the enum above. The **SSE trade-update stream** reports a *richer* `event` enum that adds operational events not present as a status — including `held` (multi-leg secondary legs awaiting trigger), `trade_bust`, `trade_correct`, `restated`, `order_cancel_rejected`, `order_replace_rejected`. So `held` exists as a trade *event* but never as an order *status*. See `alpaca-broker-sse-events`.
+
+**Terminal:** `filled`, `canceled`, `expired`, `rejected` (and `replaced` for the original order). **Everything else is in-flight.**
+
+**Early-state distinctions (these trip people up):**
+- `accepted` — received by Alpaca, not yet routed to a venue (common outside market hours).
+- `new` — received **and routed to exchanges**; the usual initial live state.
+- `pending_new` — routed but not yet accepted for execution (rare).
+
+So the typical opening sequence is `accepted → pending_new → new`, then fills. **Lesson:** treat `new`/`accepted`/`pending_new` as "exists but not done." Persist the order on submit, then update on fill/cancel/reject events — don't block the user waiting for a terminal state synchronously.
+
+## 5. Positions & trading account
+
+**`Position`** key fields: `symbol`, `asset_id`, `qty`, `qty_available` (free of open orders), `side` (`long`/`short`), `avg_entry_price`, `market_value`, `cost_basis`, `unrealized_pl`, `unrealized_plpc`, `current_price`, `change_today`.
+
+**`TradeAccount`** key fields:
+- `buying_power` (with margin `multiplier` 1–4), `cash`, `cash_withdrawable`, `equity`, `last_equity`.
+- Blockers: `trading_blocked`, `account_blocked`, `transfers_blocked`, `trade_suspended_by_user`.
+- `multiplier`, `regt_buying_power`, `non_marginable_buying_power`, `long_market_value`, `initial_margin`, `maintenance_margin`, `sma`.
+
+**Lesson — check buying power before notional orders.** For a "spend $X" UX, read `buying_power`/`cash` first and reject/notify on insufficient funds, rather than letting Alpaca reject the order. (Cache it per account within a batch run to avoid re-fetching.)
+
+> **PDT/day-trade fields are deprecated** (since 2026-04-27, sunset 2026-07-06) following FINRA's intraday-margin rule change: `daytrade_count`, `pattern_day_trader`, `daytrading_buying_power`, `bod_dtbp`, plus config `dtbp_check`/`pdt_check`. They still exist in the schema today but stop relying on them.
+
+## 6. Documented gotchas
+
+- **Wash-trade rejection (403):** if a user's two orders could self-cross (opposite sides, crossable prices), Alpaca rejects. Opposing market/stop pairs are always rejected; opposing limits rejected when buy-limit ≥ sell-limit. **Use `bracket`/`oco`/`trailing_stop` for simultaneous take-profit + stop-loss** — they're exempt.
+- **Bracket constraints:** requires both `take_profit.limit_price` and `stop_loss.stop_price`; TP must be above SL for a buy; no extended hours; TIF `day`/`gtc`; child legs activate only after the entry fully fills; canceling one cancels the group.
+- **Notional orders can't be replaced** — cancel and resubmit (IPO-class notional is the exception). Fractional `qty` can't be changed on replace ("full shares only").
+- **Replace ≠ guaranteed:** a `200` from PATCH can still be rejected if the original fills first; watch the trade-updates stream. Can't replace while `accepted`/`pending_new`/`pending_cancel`/`pending_replace`.
+- **Cancel semantics:** single cancel → `204`, or `422` if no longer cancelable; cancel-all → `207` per-order results; close-all positions → `207`. Close-single accepts mutually-exclusive `qty` or `percentage`.
+
+## 7. Idempotency & recurring-invest lessons
+
+- **Always set `client_order_id`** from your own transaction record. It's your dedup key and lets you look the order up (`orders:by_client_order_id`) if the create response is lost. Note it dedups *lookup*, not necessarily *replay* — combine it with a local "already-submitted?" guard.
+- **Recurring/scheduled buys (lesson):** the robust pattern is — fetch pending invest instructions from your DB → check buying power → place a `notional` `market`/`day` order per instruction → record the returned order → mark the instruction done **only after** a successful create. On insufficient funds, cancel the instruction and notify, don't silently skip. Schedule the batch shortly **before** market open and respect the market clock (`alpaca-broker-market-data`).
+- Track fills via the **trade events SSE stream**, not by polling each order — see `alpaca-broker-sse-events`.
+
+**Related skills:** prices/assets/clock → `alpaca-broker-market-data`; fills in real time → `alpaca-broker-sse-events`; rate limits on bulk placement → `alpaca-broker-rate-limits-resilience`; money formatting → `alpaca-broker-money-precision`.

--- a/skills/broker-api/trading-orders/reference.md
+++ b/skills/broker-api/trading-orders/reference.md
@@ -1,0 +1,21 @@
+# Trading on Behalf of Accounts Reference
+
+Companion to `SKILL.md`. Read the workflow and guardrails there first.
+
+## Primary docs and schemas
+
+- Guides: `https://docs.alpaca.markets/docs/orders-at-alpaca`, `https://docs.alpaca.markets/docs/fractional-trading`
+- API ref: `https://docs.alpaca.markets/reference/postorder`
+- Live schema: `alpaca-docs` MCP → `get-endpoint` title `"Broker API"` path `/v1/trading/accounts/{account_id}/orders`
+
+## Live schema workflow
+
+Prefer live Alpaca documentation before generating code that opens accounts, moves money, places orders, or mutates production state:
+
+1. Check `https://docs.alpaca.markets/llms.txt` or `https://docs.alpaca.markets/llms-full.txt` for the current documentation index.
+2. If an `alpaca-docs` MCP server is connected, use it for exact endpoint schemas instead of guessing from examples.
+3. Verify required fields, enum values, pagination, and status transitions against the current Broker API, Trading API, or Market Data API spec.
+
+## Related broker skills
+
+`alpaca-broker-integration`, `alpaca-broker-account-onboarding`, `alpaca-broker-funding-transfers`, `alpaca-broker-journals`, `alpaca-broker-market-data`, `alpaca-broker-sse-events`, `alpaca-broker-reconciliation-idempotency`, `alpaca-broker-rate-limits-resilience`, `alpaca-broker-money-precision`


### PR DESCRIPTION
## Summary
- Add Broker API skills for integration, onboarding, funding, journals, trading, market data, SSE events, reconciliation, rate limits, and money precision
- Add required `reference.md` companions and `alpaca-broker-*` skill names under `skills/broker-api/`
- Update broker docs and the root skills table to include the new Broker API skills

## Type of change
- [x] New skill
- [ ] Improvement to existing skill
- [ ] Bug fix
- [x] Documentation / repo infrastructure

## Checklist
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] Skill lives under `skills/trading-api/` or `skills/broker-api/`
- [x] Skill `name` follows `alpaca-<product-scope>-<skill-name>` (`trading` or `broker`)
- [x] `SKILL.md` has `name` + `description` frontmatter
- [x] `reference.md` exists alongside `SKILL.md`
- [x] No API keys or secrets committed
- [x] Disclosure language included for trading-related outputs (if applicable)
- [x] Updated [README.md](../README.md) skills table (if adding or renaming a skill)

## Test plan
- [x] `python3 scripts/validate_skills.py`
- [x] `npx skills add . --list` finds 11 skills