### PR TITLE
Add alpaca-trading-signal-parity skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ cp -r path/to/alpaca-skills/skills/trading-api/backtest .cursor/skills/alpaca-tr
 | `alpaca-trading-paper-trading` | [skills/trading-api/paper-trading/](skills/trading-api/paper-trading/) | Paper Trading | Trading API |
 | `alpaca-trading-paper-trading-cli` | [skills/trading-api/paper-trading-cli/](skills/trading-api/paper-trading-cli/) | Paper Trading (CLI) | Trading API |
 | `alpaca-trading-paper-trading-mcp` | [skills/trading-api/paper-trading-mcp/](skills/trading-api/paper-trading-mcp/) | Paper Trading (MCP Server) | Trading API |
+| `alpaca-trading-signal-parity` | [skills/trading-api/signal-parity/](skills/trading-api/signal-parity/) | Signal Parity | Trading API |
 | `alpaca-broker-integration` | [skills/broker-api/integration/](skills/broker-api/integration/) | Broker API Integration | Broker API |
 | `alpaca-broker-account-onboarding` | [skills/broker-api/account-onboarding/](skills/broker-api/account-onboarding/) | Account Onboarding & KYC | Broker API |
 | `alpaca-broker-funding-transfers` | [skills/broker-api/funding-transfers/](skills/broker-api/funding-transfers/) | Funding & Transfers | Broker API |

--- a/skills/trading-api/signal-parity/SKILL.md
+++ b/skills/trading-api/signal-parity/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: alpaca-trading-signal-parity
+description: >
+  Guarantee that a strategy's backtest and its live or paper execution compute
+  signals from the same code, and prove it with a gate that can fail. Use when a
+  backtested strategy is about to be traded, when a backtest and a running
+  strategy disagree, or when signal logic exists in more than one place.
+---
+
+# Trading API Signal Parity
+
+Use this skill when a strategy is moving from research to execution, or is
+already running in both places. A backtest earns trust by being reproducible.
+That trust transfers to the account only if the code that produced the
+backtested signals is the same code that produces the live ones. This skill
+makes that sameness explicit, mechanical, and testable.
+
+This skill does not backtest and does not place orders. It sits between
+`alpaca-trading-backtest` and `alpaca-trading-paper-trading`, and it hardens the
+seam those two share.
+
+## Required disclosures
+
+Every report, `notes.md`, `parity.md`, or exported result produced under this
+skill should include:
+
+> **Important disclosure**  
+> This material is for research and educational purposes only and is not
+> investment advice, a recommendation, an offer, or a solicitation to buy or
+> sell securities, options, cryptocurrencies, or any other financial product.
+> Signal parity establishes that two code paths agree with each other. It does
+> not establish that the strategy is profitable, that historical results will
+> repeat, or that live execution will match a simulation — fills, latency,
+> liquidity, fees, market impact, and data-feed differences remain. All
+> investments involve risk and may lose value. Review Alpaca's disclosures and
+> agreements at [alpaca.markets/disclosures](https://alpaca.markets/disclosures).
+
+When paper trading appears in the workflow, add:
+
+> Paper trading is a simulated environment. It does not involve real money or
+> actual securities transactions. Paper results may differ from live trading
+> because of fill assumptions, market impact, liquidity, latency, data
+> differences, order handling, fees, and other market conditions.
+
+## The failure this prevents
+
+Signal logic is written twice more often than anyone intends. The backtest is
+written first, in a research script optimized for vectorized speed over a full
+history. The executor is written second, weeks later, in a scheduled job that
+sees one bar at a time. Both compute "RSI(14) ≤ 30". Neither imports the other.
+
+They then drift, and every route is quiet:
+
+- One uses Wilder's smoothing, the other a simple moving average. Both are
+  called RSI. They cross the threshold on different days.
+- The research script computes indicators over the full series; the executor
+  warms up on a shorter window and reports a different value for the same bar.
+- A threshold is tuned in the research script and never copied across.
+- A TA library is upgraded. One path picks it up; the other has it pinned.
+- The backtest reads adjusted bars; the executor reads raw. Every split silently
+  becomes a signal difference.
+
+None of these fail loudly. The backtest stays green, the job keeps running, the
+account keeps trading — and the numbers that justified the strategy describe
+code that is no longer the code placing orders. The strategy was never tested;
+its twin was.
+
+**The rule this skill enforces: one signal implementation, imported by both
+paths, with a gate that fails when they diverge.**
+
+## Prerequisites
+
+- A strategy with at least one backtest run and one execution path (live, paper,
+  or scheduled). If execution does not exist yet, apply this skill anyway —
+  retrofitting parity is far more expensive than starting with it.
+- A test runner that can fail a build (`pytest`, `node --test`, or equivalent).
+- Alpaca credentials via environment variables (`ALPACA_API_KEY`,
+  `ALPACA_SECRET_KEY`). Never hardcode keys, and never write them into artifacts.
+- Historical bars for the parity fixture, via the Alpaca CLI or Market Data API.
+  See [reference.md](reference.md) for the commands.
+
+## Required workflow
+
+Work through these in order. Do not skip step 6.
+
+### 1. Inventory every place a signal is computed
+
+Search the workspace for indicator names, threshold constants, and comparison
+operators against them. List each hit with its file, and state plainly which
+ones are reachable from the backtest and which from the executor. Report the
+list before changing anything — the user usually does not know how many copies
+exist.
+
+### 2. Extract one pure signal module
+
+Move signal computation into a single module with no I/O, no network calls, no
+clock reads, and no credentials. It takes bars and parameters and returns
+signals. Purity is not style here: an impure module cannot be given a fixed
+input, and a module that cannot be given a fixed input cannot be compared
+against itself.
+
+```python
+# signals.py — the only place a signal is decided
+def rsi(closes: list[float], period: int = 14) -> list[float | None]:
+    """Wilder's RSI. Returns None for bars before the warm-up completes."""
+    ...
+
+def decide(bars: list[dict], params: dict) -> list[str]:
+    """Return one of 'buy' | 'sell' | 'hold' per bar. No I/O, no clock."""
+    ...
+```
+
+Keep the warm-up contract explicit: a bar that cannot yet be evaluated returns
+`None`/`hold`, never a silently truncated series. Warm-up mismatches are the
+most common cause of a parity failure, and the hardest to see.
+
+### 3. Make both callers import it
+
+The backtest runner and the executor both import `decide`. Neither reimplements
+it, neither copies a threshold, neither "adjusts it slightly for live". If the
+executor needs a single-bar interface, give the module one and have it call the
+same core — do not fork the logic to get a different shape.
+
+Delete the old implementations in the same change. A superseded copy left in the
+tree is the next drift.
+
+### 4. Fingerprint the module
+
+Record a SHA-256 of the signal module's source in every backtest run folder, and
+in whatever the executor writes as its own state or startup log.
+
+```
+signal_module_sha256: 9f2c...  # of signals.py
+params_sha256:        4ab1...  # of the resolved parameter set
+```
+
+The fingerprint is what makes a report auditable after the fact. Without it,
+"this backtest justified this position" is a claim about the past that nobody
+can check.
+
+### 5. Write the parity gate
+
+Feed one fixed bar fixture through both paths and assert the signal sequences
+are identical, element by element — not aggregate counts, not trade totals.
+Aggregates hide offsetting differences.
+
+The gate belongs in the test suite that already blocks the build. A gate in a
+script someone remembers to run is not a gate.
+
+```python
+def test_backtest_and_executor_agree():
+    bars = load_fixture("fixtures/parity_bars.json")   # committed, not fetched
+    assert backtest_signals(bars) == [executor_signal(bars[:i + 1])
+                                      for i in range(len(bars))]
+```
+
+Commit the fixture. A gate that fetches its own data fails on API outages, gives
+different verdicts on different days, and cannot be trusted to mean what it said
+yesterday.
+
+### 6. Prove the gate can fail
+
+**A parity gate that has never been red is not known to work.** Add a positive
+control that injects a defect and asserts the gate catches it. At minimum:
+
+- change a threshold in a copy of the params → gate red;
+- shift the warm-up by one bar → gate red;
+- swap Wilder's smoothing for a simple average → gate red;
+- leave everything correct → gate green.
+
+Run it and show the output. A green parity gate over a blind comparison is
+indistinguishable from a green gate over a working one, and the blind version is
+worse than nothing because it is trusted.
+
+### 7. Block execution on fingerprint mismatch
+
+At executor startup, compare the fingerprint of the loaded signal module against
+the one recorded by the backtest that authorized the strategy. A mismatch is a
+**hard block, not a warning** — the same posture `alpaca-trading-paper-trading`
+takes toward live credentials.
+
+Fail closed: if the fingerprint is missing, unreadable, or empty, block. A gate
+that opens when it has nothing to say is the most dangerous kind, because it is
+silent exactly when something is wrong.
+
+## Artifact contract
+
+Write a `parity/` folder alongside the backtest run folder:
+
+```
+parity/
+  parity.md          # what was unified, what was deleted, what remains a caveat
+  parity.json        # fingerprints, fixture hash, gate result, timestamp
+  fixtures/
+    parity_bars.json # the committed bar fixture the gate runs on
+```
+
+Schemas are in [reference.md](reference.md).
+
+## Guardrails
+
+1. **One implementation.** If an indicator exists in two files, parity is not
+   achieved, however well the two agree today.
+2. **No "backtest-only" variants.** A faster vectorized path is allowed only if
+   it is the same module and the gate proves both shapes agree.
+3. **Pin the indicator library.** An unpinned TA dependency makes the fingerprint
+   a claim about your code and a lie about your signals. Record the resolved
+   version next to the fingerprint.
+4. **Same data contract on both sides.** Adjusted vs raw bars, feed selection,
+   and session filtering are part of the signal. State them in `parity.md`, and
+   pin them in the fixture.
+5. **Element-wise assertions only.** Comparing trade counts or returns lets two
+   different signal series pass.
+6. **Fingerprint mismatch blocks; missing fingerprint blocks.**
+7. **Never write credentials into `parity.json`, fixtures, or logs.**
+8. **Parity is not profitability.** Say so in every report. Two paths agreeing
+   proves they are the same strategy, not that the strategy works.
+
+## In-chat response standard
+
+Report, in this order:
+
+1. How many signal implementations were found, and where.
+2. What was unified and what was deleted.
+3. The parity gate result, plus **the positive control output** proving it can
+   fail. A parity claim without the red proof is incomplete.
+4. Fingerprints and the pinned indicator-library version.
+5. Remaining caveats — anything the gate does not cover (fills, latency,
+   slippage, partial fills, market impact).
+6. The required disclosure.
+
+## Troubleshooting
+
+**The gate is red and both paths look correct.** Print the first differing index
+and the inputs around it. It is almost always warm-up: the executor has fewer
+prior bars than the backtest had at the same timestamp.
+
+**The gate goes green after a refactor that should have broken it.** The gate is
+probably comparing a cached result, or the fixture is shorter than the warm-up
+window and every entry is `hold`. Re-run the positive control.
+
+**The executor needs data the pure module cannot fetch.** Correct — it should
+not. Fetch outside, pass bars in. If a signal genuinely needs a second series,
+make it a second argument, not a network call inside the module.
+
+**Parity holds but live results still diverge from the backtest.** Expected, and
+outside this skill's scope: parity covers signal generation only. Fills,
+latency, slippage, fees, and liquidity live in the execution layer. Say this
+explicitly rather than letting a green gate imply more than it proves.
+
+## Related files
+
+- [reference.md](reference.md)

--- a/skills/trading-api/signal-parity/reference.md
+++ b/skills/trading-api/signal-parity/reference.md
@@ -1,0 +1,150 @@
+# Signal Parity Reference
+
+Schemas, formulas, and commands for [SKILL.md](SKILL.md).
+
+## Building the parity fixture
+
+The fixture is a committed slice of historical bars that the gate replays on
+every run. Choose a window that contains at least one of every signal the
+strategy can emit, plus the full warm-up period before the first one.
+
+```bash
+# Daily bars for the fixture window (CSV, then convert to JSON in the workspace)
+alpaca data bars --symbol AAPL --start 2025-01-01 --end 2025-06-30 \
+  --timeframe 1Day --csv > fixtures/parity_bars.csv
+
+# Confirm the CLI is authenticated and reachable before generating a fixture
+alpaca version && alpaca doctor
+```
+
+Credentials come from `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` in the
+environment. Never inline them into commands, fixtures, or artifacts.
+
+**Fixture rules**
+
+| Rule | Why |
+| --- | --- |
+| Commit it | The gate must give the same verdict today and next quarter |
+| Cover warm-up + first signal | A fixture shorter than the warm-up emits only `hold`, and passes blind |
+| Record feed and adjustment | `sip`/`iex` and adjusted/raw are part of the signal, not transport |
+| Hash it | A silently edited fixture turns a red gate green |
+
+## `parity.json`
+
+```json
+{
+  "schema": "alpaca-signal-parity/1",
+  "generated_at": "2026-08-30T09:14:22Z",
+  "signal_module": {
+    "path": "signals.py",
+    "sha256": "9f2c8a...",
+    "pure": true
+  },
+  "params": {
+    "resolved": { "rsi_period": 14, "entry_rsi_max": 30, "exit_rsi_min": 70 },
+    "sha256": "4ab1d7..."
+  },
+  "indicator_library": { "name": "ta-lib", "version": "0.4.28", "pinned": true },
+  "data_contract": {
+    "feed": "sip",
+    "adjustment": "split_and_dividend",
+    "timeframe": "1Day",
+    "session": "regular"
+  },
+  "fixture": { "path": "fixtures/parity_bars.json", "bars": 124, "sha256": "e30b91..." },
+  "gate": {
+    "result": "pass",
+    "compared": "element-wise",
+    "signals": 124,
+    "first_divergence_index": null
+  },
+  "positive_control": {
+    "run_at": "2026-08-30T09:14:25Z",
+    "cases": 4,
+    "red_as_expected": 3,
+    "green_as_expected": 1
+  },
+  "callers": ["backtest/run.py", "executor/watch.py"]
+}
+```
+
+`gate.result` may be `pass` or `fail`. `positive_control` is required: a
+`parity.json` without it records an unproven gate, and should be treated as a
+failed run.
+
+## `parity.md` outline
+
+1. Signal implementations found — file, reachable from which path
+2. What was unified; what was deleted
+3. Data contract on each side, and any difference that had to be reconciled
+4. Gate result, element-wise, with the first divergence index if any
+5. Positive-control table (below)
+6. What parity does **not** cover — fills, latency, slippage, fees, liquidity
+7. Required disclosure from [SKILL.md](SKILL.md)
+
+## Positive-control matrix
+
+The minimum set. Each row states the injected defect and the expected verdict.
+
+| # | Injected defect | Expected |
+| --- | --- | --- |
+| 0 | none — healthy fixture and module | green |
+| 1 | entry threshold changed in one path's params | red |
+| 2 | warm-up shifted by one bar | red |
+| 3 | Wilder's smoothing replaced with a simple average | red |
+| 4 | adjusted bars on one side, raw on the other | red |
+| 5 | fixture truncated below the warm-up window | red (or the gate is blind) |
+
+Case 5 is the one most often missing. A fixture shorter than the warm-up makes
+every signal `hold`, both paths agree trivially, and the gate reports success
+while comparing nothing.
+
+## Wilder's RSI
+
+The definition mismatch behind most parity failures. Wilder's smoothing is not
+a simple moving average, and both are called "RSI(14)".
+
+```
+change[i]  = close[i] - close[i-1]
+gain[i]    = max(change[i], 0)
+loss[i]    = max(-change[i], 0)
+
+# Seed (first value at i = period):
+avg_gain[period] = mean(gain[1..period])
+avg_loss[period] = mean(loss[1..period])
+
+# Wilder's smoothing thereafter:
+avg_gain[i] = (avg_gain[i-1] * (period - 1) + gain[i]) / period
+avg_loss[i] = (avg_loss[i-1] * (period - 1) + loss[i]) / period
+
+rs[i]  = avg_gain[i] / avg_loss[i]        # avg_loss == 0 → RSI = 100
+rsi[i] = 100 - (100 / (1 + rs[i]))
+```
+
+Bars before index `period` have no defined RSI. Return `None` for them; do not
+seed with zeros and do not drop them silently — either choice shifts every
+downstream index and produces exactly the off-by-one the gate exists to catch.
+
+## Computing fingerprints
+
+```bash
+# Signal module
+shasum -a 256 signals.py | cut -d' ' -f1
+
+# Resolved parameters — canonicalize first, or key order becomes false drift
+python3 -c "import json,hashlib,sys; \
+print(hashlib.sha256(json.dumps(json.load(open('params.json')), sort_keys=True, \
+separators=(',',':')).encode()).hexdigest())"
+```
+
+Canonicalization matters: serializing a dict without `sort_keys` makes an
+unchanged parameter set produce a new hash whenever key order shifts, and a gate
+that raises false alarms is switched off within a week.
+
+## Related skills
+
+| Skill | Relationship |
+| --- | --- |
+| `alpaca-trading-backtest` | Produces the run this skill fingerprints |
+| `alpaca-trading-paper-trading` | The execution path that must import the same module |
+| `alpaca-trading-paper-trading-cli` | Same, when execution is driven by the CLI |


### PR DESCRIPTION
## What this adds

A skill for the seam between `alpaca-trading-backtest` and `alpaca-trading-paper-trading`: proving that a strategy's backtest and its execution compute signals from **the same code**.

## Why

Signal logic tends to get written twice — once in a vectorized research script over a full history, once in a scheduled executor that sees one bar at a time. Both are called `RSI(14) <= 30`. Neither imports the other.

They then drift, and every route is quiet:

- Wilder's smoothing on one side, a simple moving average on the other — both named RSI, crossing the threshold on different days
- warm-up windows that differ, shifting every downstream index
- an unpinned TA library upgraded on one side only
- adjusted bars in the backtest, raw bars in the executor — every split becomes a signal difference
- a threshold tuned in research and never copied across

None of these fail loudly. The backtest stays green and the account keeps trading, but the numbers that justified the strategy describe code that is no longer placing the orders.

## What the skill enforces

- **One pure signal module** (no I/O, no clock, no credentials) imported by both paths, with the superseded copies deleted in the same change
- **SHA-256 fingerprints** of the module and the resolved parameters, recorded in backtest artifacts and checked at executor startup — mismatch blocks, and a missing or unreadable fingerprint blocks too, so the gate fails closed
- **An element-wise parity gate** over a committed bar fixture, in the suite that already blocks the build. Aggregate comparisons (trade counts, returns) let two different signal series pass
- **A positive control.** A parity gate that has never been red is not known to work, and a blind green gate is worse than none because it is trusted

`reference.md` carries the `parity.json` schema, the Wilder's RSI definition behind most parity failures, fingerprint commands with canonicalized parameter hashing, and the minimum defect matrix — including the case most often missed: a fixture shorter than the warm-up window, where every signal is `hold`, both paths agree trivially, and the gate reports success while comparing nothing.

The skill explicitly scopes itself: parity covers signal generation only. Fills, latency, slippage, fees, and liquidity stay in the execution layer, and the skill requires that to be said out loud rather than letting a green gate imply more than it proves.

## Conventions

- `skills/trading-api/signal-parity/` with the required `SKILL.md` + `reference.md` pairing
- Name `alpaca-trading-signal-parity`, frontmatter limited to `name` and `description`
- Required disclosure language in outputs, adapted from the existing backtest skill; paper-trading disclosure included
- Credentials referenced as `ALPACA_API_KEY` / `ALPACA_SECRET_KEY` only, never inlined
- Relative cross-references; README skill table updated
- `python3 scripts/validate_skills.py` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
