### PR TITLE
fix: align broker skills with current Alpaca docs

### DIFF
--- a/skills/broker-api/account-onboarding/SKILL.md
+++ b/skills/broker-api/account-onboarding/SKILL.md
@@ -71,7 +71,7 @@ Four objects are **required**: `contact`, `identity`, `disclosures`, `agreements
 - `contact.street_address` is an **array** (max 3 lines). `contact.state` required when country/tax-residence is `USA`.
 - `identity.funding_source` is an array; one+ of `employment_income`, `investments`, `inheritance`, `business_income`, `savings`, `family`.
 - `tax_id_type` enum is large and country-specific: `USA_SSN`, `USA_ITIN`, `IND_PAN`, `MEX_RFC`, `GBR_NINO`, … plus generic `NATIONAL_ID`, `PASSPORT`, `DRIVER_LICENSE`, `OTHER_GOV_ID`, `NOT_SPECIFIED`. Query the spec for the full list rather than hardcoding.
-- Optional top-level: `account_type` (`trading`|`custodial`|`donor_advised`|`ira`), `account_sub_type` (IRA: `traditional`|`roth`), `enabled_assets` (`us_equity`|`us_option`|`crypto`|`ipo`, default `us_equity`).
+- Optional top-level: `account_type` (`trading`|`custodial`|`donor_advised`|`ira`), `account_sub_type` (IRA: `traditional`|`roth`), `enabled_assets` (`us_equity`|`us_option`|`crypto`|`ipo`, default `us_equity`), `allow_instant_ach` (default `false` — the partner-side switch for Instant ACH).
 - **Deprecated:** `investment_objective`/`investment_time_horizon`/`liquidity_needs`/`risk_tolerance` moved from `identity` to **top-level**.
 
 **Responses:** `200` → account object · `409` email already registered · `422` invalid value · `400` malformed body.
@@ -91,6 +91,7 @@ Each entry: `agreement` (`customer_agreement`, `account_agreement`, `margin_agre
 - `document_type` enum includes `identity_verification`, `address_verification`, `date_of_birth_verification`, `tax_id_verification`, `w8ben`, `w9`, `cip_result`, and more.
 - `mime_type`: `application/pdf`, `image/png`, `image/jpeg` — plus `application/json` **only** for `w8ben`.
 - **W-8BEN shortcut (lesson):** instead of generating a PDF, upload `content_data` as a structured `W8benDocument` JSON object (full_name, country_citizen, permanent_address_*, date_of_birth, ip_address, timestamp, signer_full_name, …) and **Alpaca renders the official form for you**. This is the clean way to satisfy the tax-form requirement for non-US persons programmatically.
+- **W-8BEN expires.** A new form must be submitted every three years, in addition to the calendar year it was signed — schedule the renewal, don't treat the upload as one-and-done.
 - Doc size cap: **10 MB** per file when using Alpaca's KYC-as-a-service; no cap if you run your own KYC.
 
 ## 5. Account status lifecycle
@@ -99,35 +100,37 @@ Each entry: `agreement` (`customer_agreement`, `account_agreement`, `margin_agre
 
 | Status | Meaning |
 |--------|---------|
-| `ONBOARDING` | Application expected, not yet submitted |
+| `INACTIVE` | Not enabled for the given asset |
+| `PAPER_ONLY` | Limited to paper trading |
+| `ONBOARDING` | Created but KYC not yet performed — **only used with Onfido** (the OpenAPI enum text still describes it as "application expected, not yet submitted") |
 | `SUBMITTED` | Submitted, being processed |
-| `SUBMISSION_FAILED` | Submission error |
-| `ACTION_REQUIRED` | Needs manual action (e.g. a `true` disclosure routes here) |
-| `APPROVAL_PENDING` | Approval in progress (documented "initial value") |
+| `SUBMISSION_FAILED` | Submission error; Alpaca resolves these, no action needed |
+| `ACTION_REQUIRED` | Manual action + a document upload from the user (e.g. a `true` disclosure routes here); see `kyc_results` |
+| `APPROVAL_PENDING` | The account did not pass the automatic KYC check, so the team reviews manually — usually no document required |
 | `APPROVED` | Approved, waiting to go active |
 | `ACTIVE` | **Fully usable** — funding & trading allowed |
 | `REJECTED` | Application rejected |
-| `ACCOUNT_UPDATED` | Modified by user |
+| `ACCOUNT_UPDATED` | Personal information under review; transient, returns to `ACTIVE`. Outgoing transfers are restricted meanwhile |
 | `ACCOUNT_CLOSED` | Closed |
-| `INACTIVE` | Not enabled for the given asset |
 
-**Happy path:** `SUBMITTED → APPROVAL_PENDING → APPROVED → ACTIVE`.
+**Happy path:** `SUBMITTED → APPROVED → ACTIVE`. `APPROVAL_PENDING` and `ACTION_REQUIRED` are the exception branches when the automatic KYC check does not pass; either can rejoin at `APPROVED` or end in `REJECTED`. (The OpenAPI enum still calls `APPROVAL_PENDING` the "initial value"; the statuses guide is the newer source.)
 
-**Lesson — gate every downstream op on `ACTIVE`.** A `200` from `POST /v1/accounts` does *not* mean tradable. Subscribe to account-status SSE events (or poll `GET /v1/accounts/{id}`) and only enable funding/journals/trading once `status == ACTIVE`. Trying to journal or trade into a non-active account fails.
+**Lesson — gate every downstream op on `ACTIVE`.** A `200` from `POST /v1/accounts` does *not* mean tradable. Subscribe to account-status SSE events (or poll `GET /v1/accounts/{id}`) and only enable funding/journals/trading once `status == ACTIVE`. Trying to journal or trade into a non-active account fails. Gate crypto on `crypto_status`, which tracks separately from `status`. Treat `ACCOUNT_UPDATED` as transient-restricted rather than failed — the account returns to `ACTIVE` after review.
 
 ## 6. KYC results & CIP
 
-- `kyc_results` on the account object carries `reject`/`accept`/`indeterminate` categories (`KYCResultType` values like `IDENTITY_VERIFICATION`, `TAX_IDENTIFICATION`, `ADDRESS_VERIFICATION`, `WATCHLIST_HIT`, `COUNTRY_NOT_SUPPORTED`, `OTHER`) plus `additional_information`. `summary` is `pass`/`fail` (internal only).
+- `kyc_results` on the account object carries `reject`/`accept`/`indeterminate` sets plus `additional_information`. `summary` is `pass`/`fail` (internal only).
+- **`KYCResultType` is an extensible string set, not a closed enum.** Examples only: `IDENTITY_VERIFICATION`, `WATCHLIST_HIT`, `W8BEN_CORRECTION`. Generated code must tolerate and preserve unrecognized values rather than parsing into a fixed enum. The documented identifiers live under `KYCResults` at `https://docs.alpaca.markets/reference/getaccount`.
 - If you run KYC yourself (or via Onfido/Trulioo/Veriff/etc.), submit results via `POST /v1/accounts/{id}/cip` with a `CIPInfo` body (provider_name, kyc, document, photo, identity, watchlist sub-results). Sub-check results are `clear`/`consider`.
 - Minimum to open an individual account: verify **name, date of birth, address, and identification number**.
-- `WATCHLIST_HIT` / `COUNTRY_NOT_SUPPORTED` require no user action — Alpaca handles them manually.
+- `WATCHLIST_HIT` needs no action from the account owner unless Alpaca separately requests it.
 
 ## 7. Integration guidance & lessons learned
 
 1. **Normalize inputs to canonical formats before sending.** Country fields must be **ISO 3166-1 alpha-3** (`USA`, `PHL`, …) — strip any UI decoration (flags/emoji, display names) and validate against `GET /v1/country-info`. Garbage in `country`/`country_of_tax_residence` is a common 422.
 2. **Capture real agreement metadata.** `signed_at` and `ip_address` must reflect the actual user action, not server time / a placeholder.
 3. **Treat creation as async.** Persist the returned `account_id` immediately, then drive UI off the **status events**, not the create response.
-4. **Guard against paper/test accounts in production code paths.** If you run both sandbox and live, make sure live event handlers reject sandbox/paper account IDs rather than silently mutating real records.
+4. **Keep sandbox and live credentials/config in separate deployments.** There is nothing in an account id to check — ids are plain UUIDs, and the two environments are separate hosts with separate credentials.
 5. **Idempotency on submit.** A `409` on duplicate email is your friend — look up the existing account rather than retrying creation. Store your local user↔`account_id` mapping before the network call so a timeout doesn't orphan an account.
 6. **Closing is your responsibility to sequence.** Before `POST .../actions/close`, you must liquidate all positions and withdraw all cash. The account record is not deleted — it goes `ACCOUNT_CLOSED`.
 

--- a/skills/broker-api/funding-transfers/SKILL.md
+++ b/skills/broker-api/funding-transfers/SKILL.md
@@ -5,7 +5,7 @@ description: Move money between an Alpaca brokerage account and the EXTERNAL ban
 
 # Alpaca Broker API — Funding & Transfers
 
-Getting cash into and out of end-user accounts. There are **three rails**, and the model splits cleanly into *bank links* (persistent) and *transfers* (the actual money movement).
+Getting cash into and out of end-user accounts. There are **three external rails** plus Instant Funding, and for the external rails the model splits cleanly into *bank links* (persistent) and *transfers* (the actual money movement).
 
 > Read `alpaca-broker-integration` first. Broker API + HTTP Basic auth. For moving cash *between* accounts in your omnibus (vs. to/from the outside world), see `alpaca-broker-journals` — that's a different mechanism.
 
@@ -32,6 +32,7 @@ Funding wallet    (rail C: v1beta, multi-currency)  ┘
 | **ACH** | `ach` | `INCOMING` + `OUTGOING` | ACH relationship (`relationship_id`) | US domestic; set up via Plaid `processor_token` (recommended) |
 | **Wire** | `wire` | `OUTGOING` only | Bank relationship (`bank_id`) | Domestic + international (SWIFT). Incoming wires are pushed by the sending bank and booked automatically |
 | **Funding wallet** | (separate `/v1beta` API) | `incoming` / `outgoing` (lowercase) | Funding-wallet recipient bank | Multi-currency, `swift_wire`/`local_rails` |
+| **Instant Funding** | (separate `/v1/instant_funding` API) | credit only | none — you collect the payment yourself | Extends buying power immediately, settled in bulk by wire on T+1. See §8 |
 
 ## 2. Endpoints
 
@@ -43,12 +44,18 @@ Funding wallet    (rail C: v1beta, multi-currency)  ┘
 | GET | `/v1/accounts/{id}/transfers` | List transfers |
 | DELETE | `/v1/accounts/{id}/transfers/{transfer_id}` | Request cancel |
 | POST/GET | `/v1beta/accounts/{id}/funding_wallet` | Create / get funding wallet |
+| GET | `/v1beta/accounts/{id}/funding_wallet/funding_details` | Deposit instructions for the wallet |
 | POST/GET/DELETE | `/v1beta/accounts/{id}/funding_wallet/recipient_bank` | Funding-wallet recipient bank |
 | POST | `/v1beta/accounts/{id}/funding_wallet/withdrawal` | Funding-wallet withdrawal |
 | GET | `/v1beta/accounts/{id}/funding_wallet/transfers[/{transfer_id}]` | List / get wallet transfers |
+| POST/GET/DELETE | `/v1/instant_funding[/{instant_funding_id}]` | Create / get / reverse an instant funding transfer |
+| GET | `/v1/instant_funding/limits` | Correspondent-level limits (`/limits/accounts` for per-account) |
+| POST | `/v1/instant_funding/settlements` | Trigger settlement of created transfers |
 | GET | `/v2/events/funding/status` | **SSE** — unified funding status stream (see §6) |
 
 > The current wire-bank endpoint is **`/recipient_banks`** (schema `Bank`/`CreateBankRequest`). The older `/banks` name is a legacy alias.
+
+**Wallet deposit flow:** create the wallet → `GET .../funding_wallet/funding_details` for the instructions to hand the customer → customer pushes funds (in sandbox, `POST /v1beta/demo/banking/funding`) → poll `GET .../funding_wallet/transfers`.
 
 ## 3. Create-transfer request (`POST /v1/accounts/{id}/transfers`)
 
@@ -91,7 +98,7 @@ Required: `name`, `bank_code`, `bank_code_type`, `account_number`.
 
 (The SSE `Transfer` entity also reports `EXPIRED`, which is effectively terminal.)
 
-**Funding-wallet transfers (`FundingWalletTransferStatus`):** `PENDING`, `EXECUTED`, `COMPLETE`, `CANCELED`, `FAILED` (last three terminal). Note lowercase `incoming`/`outgoing` directions here — different casing from classic transfers.
+**Funding-wallet transfers:** `PENDING` → `EXECUTED` → `COMPLETE`, with `REJECTED` (bank rejected, usually bad input) and `FAILED` (bank error) as the other exits. Wallet transfers **cannot be canceled**; the terminal set is `COMPLETE` / `REJECTED` / `FAILED`. The OpenAPI `FundingWalletTransferStatus` enum still lists `CANCELED` and omits `REJECTED` — trust the guide and treat the union as terminal. Note lowercase `incoming`/`outgoing` directions here — different casing from classic transfers.
 
 ## 6. Events vs polling — the key reliability lesson
 
@@ -109,18 +116,17 @@ Required: `name`, `bank_code`, `bank_code_type`, `account_number`.
 - **Incoming wires need an FFC (For Further Credit) instruction** to auto-book; otherwise they're handled manually.
 - **Travel Rule:** Alpaca requires transmitter/originator info on **all incoming deposits regardless of amount** (below the usual FinCEN $3,000 threshold). Pass it at settlement creation; retained ≥5 years.
 - **ACH uses Plaid:** pass the bank via `processor_token`. There's an `instant` flag on the relationship. Account types limited to `CHECKING`/`SAVINGS`.
-- **`timing: immediate` is deprecated** and silently ignored (sunset 2026-08-26) — stop sending it.
-- **Permission errors:** `403` if the account's `depositable_status`/`withdrawable_status` isn't allowed; `422` for incoming-wire attempts, missing/mismatched relationship vs bank IDs, or amounts under the (undocumented) minimums.
+- **Permission errors:** `403` when the account isn't permitted to deposit or withdraw. The message names the failing permission (`depositable_status` / `withdrawable_status`); neither exists as a field on the account object, so there is nothing to pre-check — handle the 403 and surface its message. `422` for incoming-wire attempts, missing/mismatched relationship vs bank IDs, or amounts under the (undocumented) minimums.
 - **Sandbox wire behavior:** simulated end-to-end but **asynchronous** and auto-completes **on weekdays only** — weekend submissions don't progress until Monday. (ACH in sandbox settles instantly.)
 
-## 8. The omnibus / sweep-account pattern (architecture lesson)
+## 8. Instant availability: two supported models
 
-Many production brokers don't fund each user account by a separate external transfer. Instead:
+Alpaca documents two ways to let a user trade before their cash lands, with different settlement obligations.
 
-1. Users pay you through *your* payment processor (or you receive a bulk wire into a **firm/sweep account** held at Alpaca).
-2. You then **journal** cash from the firm account to the user's account instantly (`JNLC`) — no external ACH/wire per user. See `alpaca-broker-journals`.
-3. Withdrawals reverse it: journal from user → firm account, then send one external transfer out.
+**Cash pooling (omnibus + journals)** — the docs call this the most common use case: bulk-wire into your pre-funded firm account, then `JNLC` to the user the moment you receive their payment; reverse for withdrawals. You pre-fund, so you owe Alpaca nothing per transfer. Requires Alpaca review and possibly a local money-transmitter license. See `alpaca-broker-journals`.
 
-This decouples your funding UX from Alpaca's transfer rails and enables "instant" deposits. It requires Alpaca review (and possibly a local money-transmitter license) — confirm with counsel. The classic transfer endpoints in this skill then handle only the *firm-account-to-outside-world* leg.
+**Instant Funding** — `POST /v1/instant_funding` extends buying power at the user account without pre-funding, so Alpaca is extending you credit and you settle later. Per-account limit defaults to USD 1,000 (raiseable on request); correspondent headroom is `GET /v1/instant_funding/limits`, per-account headroom is `GET /v1/instant_funding/limits/accounts?account_numbers=…`.
+
+Settlement is your obligation and it is tight. Transfers batch in a 24-hour window ending 8 PM ET, you wire one bulk payment to your `SI` firm account, then call `POST /v1/instant_funding/settlements` (carrying the Travel Rule `originator_*` fields) **before 1 PM ET on T+1**. Late settlement accrues penalty interest at FED UB + 8%, invoiced monthly. Unreconciled transfers auto-cancel at **8 PM ET on T+1**, which drops the customer account into a debit balance if they already spent the credit. Full flow: `https://docs.alpaca.markets/us/docs/instant-funding`.
 
 **Related skills:** internal cash movement → `alpaca-broker-journals`; missed-status recovery → `alpaca-broker-reconciliation-idempotency`; money formatting → `alpaca-broker-money-precision`; live status → `alpaca-broker-sse-events`.

--- a/skills/broker-api/integration/SKILL.md
+++ b/skills/broker-api/integration/SKILL.md
@@ -17,7 +17,7 @@ This is the **router / overview** skill. It covers the things that are true acro
 
 - Docs home: `https://docs.alpaca.markets/`
 - API reference: `https://docs.alpaca.markets/reference/`
-- Machine-readable index: `https://docs.alpaca.markets/llms.txt` and `https://docs.alpaca.markets/llms-full.txt`
+- Machine-readable index: `https://docs.alpaca.markets/us/llms.txt` (the root `llms.txt` is the India/GIFT City index; `llms-full.txt` redirects to the docs home)
 - OpenAPI specs (4): **Authentication API**, **Broker API**, **Market Data API**, **Trading API**
 
 **Live schema lookups:** if the `alpaca-docs` MCP server is connected, prefer it over guessing — `list-specs`, `list-endpoints`, `get-endpoint` (exact request/response schemas + servers), and `search` / `fetch` (guide pages). Always confirm an exact payload against the spec before generating code that posts money or orders.
@@ -45,7 +45,7 @@ These skills focus primarily on the **Broker API**, because that's where the lif
 |--------|-----------|-----------------|
 | **Broker API** | `https://broker-api.alpaca.markets` | `https://broker-api.sandbox.alpaca.markets` |
 | **Trading API** | `https://api.alpaca.markets` | `https://paper-api.alpaca.markets` (paper) |
-| **Market Data (REST)** | `https://data.alpaca.markets` | *(same host; sandbox data is limited)* |
+| **Market Data (REST)** | `https://data.alpaca.markets` | `https://data.sandbox.alpaca.markets` |
 | **Market Data (WebSocket)** | `wss://stream.data.alpaca.markets` | `wss://stream.data.sandbox.alpaca.markets` |
 
 **Always start in sandbox.** Switch by environment variable, never by code path — a single `ENV` flag that selects the base URL is the pattern that survives. Sandbox accounts can be funded with fake money and auto-approved, so you can exercise the full lifecycle without real KYC or cash.
@@ -96,7 +96,7 @@ Alpaca gives you three transports. Use the right one for the job — and know th
 | **SSE** | `text/event-stream` over a long-lived HTTPS GET | Broker lifecycle events: account status, journals, transfers, trades, non-trade activities. **Replayable** via cursors. | `alpaca-broker-sse-events` |
 | **WebSocket** | `wss://` | Real-time market data (trades/quotes/bars). | `alpaca-broker-market-data` |
 
-**Key distinction:** Broker *events* come over **SSE** (simple HTTP, Basic auth, replayable with `since`/`since_id`). Market *data* comes over **WebSocket** (subscribe model, auth message, ping/pong). They are different endpoints with different auth — don't conflate them.
+**Key distinction:** Broker *events* come over **SSE** (simple HTTP, Basic auth, replayable with `since` or `since_ulid`/`until_ulid` on v1 and `since_id` — a ULID — on v2; the v1 integer `since_id`/`until_id` are deprecated, select partners only, sunset 2027-02-15). Market *data* comes over **WebSocket** (subscribe model, auth message, ping/pong). They are different endpoints with different auth — don't conflate them.
 
 ---
 
@@ -105,9 +105,9 @@ Alpaca gives you three transports. Use the right one for the job — and know th
 These apply everywhere and are the source of most subtle bugs:
 
 - **Numbers are strings.** Prices, quantities, notional, and money amounts come back as JSON strings (`"100.50"`, `"1.5"`). Parse into a decimal type, never a binary float. See `alpaca-broker-money-precision`.
-- **IDs:** `account_id`, `order_id`, `journal_id`, `transfer_id` are UUIDs. Activity IDs and newer event IDs are **ULIDs** — lexicographically sortable, which matters for event ordering and replay cursors.
+- **IDs:** `account_id`, `order_id`, `journal_id`, `transfer_id` are UUIDs. Activity IDs are `<timestamp>::<uuid>` strings (e.g. `20220208125959696::88b5f678-…`) — sortable, but not ULIDs. Newer event IDs (`event_ulid` on v1, `event_id` on v2) *are* **ULIDs**, which matters for event ordering and replay cursors.
 - **Idempotency:** pass your own `client_order_id` on orders so retries don't double-fill. Records you create from events should be keyed on the Alpaca ID with upsert/skip-duplicate semantics. See `alpaca-broker-reconciliation-idempotency`.
-- **Pagination:** list endpoints page forward with a token. Market-data bars return `next_page_token` in the body; activities return a page token via the `X-Next-Page-Token` response header. Loop until the token is empty.
+- **Pagination:** list endpoints page forward with a token. Market-data bars return `next_page_token` in the body; loop until it's empty. Activities send **no** token anywhere — on both Broker `/v1/accounts/activities` and Trading `/v2/account/activities` you pass the **`id` of the last activity in the page** as the `page_token` query param, and loop until a page comes back short or empty.
 - **Rate limits:** responses carry `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (unix seconds). On HTTP `429`, wait until reset before retrying. See `alpaca-broker-rate-limits-resilience`.
 - **Timestamps:** RFC3339 (e.g. `2026-01-02T15:04:05Z`). SSE `since`/`until` accept RFC3339, but `+` in a timezone offset must be URL-encoded as `%2B`.
 - **Status ≠ done.** Almost every write (account, journal, transfer, order) is asynchronous and moves through a **state machine**. A `200` means "accepted," not "settled." Always reconcile on the terminal status, which arrives later via event or poll.

--- a/skills/broker-api/journals/SKILL.md
+++ b/skills/broker-api/journals/SKILL.md
@@ -46,7 +46,7 @@ Journals move value **between two accounts within your own Alpaca omnibus** — 
 | `from_account` / `to_account` | required | required | account UUIDs |
 | `amount` | **required** | — | decimal string |
 | `symbol` / `qty` | — | **required** | qty is a string; fractional allowed |
-| `currency` | optional | optional | defaults USD |
+| `currency` | optional | optional | no documented default |
 | `description` | optional | optional | ≤1024 chars; accepts sandbox fixtures |
 | `transmitter_*` | optional (JNLC) | n/a | Travel Rule fields |
 
@@ -75,20 +75,21 @@ Pass an `Idempotency-Key` header (≤128 chars; a client-generated UUID is recom
   "entries": [ { "from_account": "<u1>", "amount": "10" }, { "from_account": "<u2>", "amount": "100" } ] }
 ```
 
-Every entry must validate or the **entire batch fails** (one bad account ID kills it). The response is an array of `BatchJournalResponse` (the Journal object + an `error_message` per entry that failed). `Idempotency-Key` is supported with the same semantics.
+Every entry must validate or the **entire batch fails** (one bad account ID kills it). They diverge after that: `/batch` accepts `Idempotency-Key` and returns `BatchJournalResponse` (the Journal object + an `error_message` per entry that failed), while `/reverse_batch` documents neither — it returns a plain array of `JNLC` with no per-item error, so guard reverse-batch replays locally.
 
 ## 5. Status lifecycle
 
-`JournalStatus`: `queued`, `sent_to_clearing`, `pending`, `executed`, `rejected`, `canceled`, `refused`, `deleted`, `correct`.
+`JournalStatus`: `queued`, `sent_to_clearing`, `pending`, `executed`, `activity_created`, `rejected`, `canceled`, `refused`, `deleted`, `correct`.
 
-**Happy path:** `queued → sent_to_clearing → executed`.
+**Happy path depends on the JNLC version Alpaca has set for you.** JNLS and JNLC v1: `queued → sent_to_clearing → executed`. JNLC v2 (single cash journals only; batches still run v1): the create response frequently comes back already `executed`, then `activity_created` follows, and `sent_to_clearing` appears only on the manual-approval path. Accept all ten statuses either way — `executed` is the one that means buying power moved.
 
 | Status | Meaning | Terminal |
 |--------|---------|----------|
 | `queued` | In queue | no |
 | `sent_to_clearing` | Submitted to books-and-records | no |
-| `pending` | Needs Alpaca ops approval (e.g. hit a JNLC daily limit) | no |
+| `pending` | Needs Alpaca ops approval (usually a JNLC limit — see §7) | no |
 | `executed` | Balances updated — **but NOT final**, can still be reversed by cashiering | no (not final) |
+| `activity_created` | Non-trade activity created (JNLC v2 only); informational, still reversible | no (not final) |
 | `rejected` | Manually rejected | no |
 | `refused` | Failed preliminary checks; never hit the ledger (e.g. a fast replay failing the balance check) | no |
 | `canceled` | Canceled via API/ops | **FINAL** |
@@ -108,7 +109,8 @@ Every entry must validate or the **entire batch fails** (one bad account ID kill
 - **Eligibility:** the cash-pooling/journals use case requires Alpaca review and possibly a local license — check with counsel.
 - **JNLS account states:** `to_account` must be `ACTIVE`; `from_account` must be `ACTIVE` or `CLOSE`.
 - **Sufficient funds:** JNLC create → `403` if the amount isn't available; reverse-batch `403` = insufficient balance/assets.
-- **Daily limits push to `pending`** (manual ops approval).
+- **JNLC limits push to `pending`** (manual ops approval): a per-transaction limit (default **$50**) and a daily aggregate limit (default **$1,000**). Both are configurable; an over-limit journal executes in the next day's BOD job.
+- **Pre-check `cash_transferable`** on the trading account — it is "Cash available for transfer (JNLC)", unlike `cash`, which counts unsettled sale proceeds.
 - **`GET /v1/journals` returns `422` if the result set exceeds 100,000 records** — always filter with `after`/`before`/`limit`.
 - **Delete is pending-only:** `DELETE` succeeds (204) only when `pending`; an executed journal → `422`. **To reverse an executed journal, create a mirror journal in the opposite direction**, don't try to delete it.
 - **Travel Rule:** include transmitter info on money-moving journals (required on all incoming deposits regardless of amount).

--- a/skills/broker-api/market-data/SKILL.md
+++ b/skills/broker-api/market-data/SKILL.md
@@ -74,7 +74,7 @@ Real-time and historical US equity data. Unlike the Broker endpoints, market dat
 - `otc`, `boats` (Blue Ocean overnight ATS), `overnight` (Alpaca-derived, cheaper).
 
 **Lessons:**
-- **Pick `iex` explicitly** if you're on the free tier — some endpoints default to `sip`, which then 403s without entitlement. (A common surprise: "why is my historical request failing?" → defaulted to SIP.)
+- **Don't hard-pin `feed=iex`** — latest/snapshot endpoints default to the best feed your subscription entitles you to, and historical endpoints default to `sip` but default `end` to 15 minutes ago when you lack real-time access, so historical SIP is queryable unsubscribed as long as `end` is at least 15 minutes old. A `403` (`{"code":42210000,"message":"subscription does not permit querying recent SIP data"}`) comes from **explicitly** asking for `feed=sip` on data you aren't entitled to.
 - Without real-time access, `start`/`end` windows **withhold the most recent 15 minutes**.
 - Trade/quote **sizes are in shares** as of 2025-11-03 (were round lots before).
 
@@ -98,7 +98,7 @@ Real-time and historical US equity data. Unlike the Broker endpoints, market dat
 **Message types** (every message is a **JSON array**; `T` discriminates): `t` trade, `q` quote, `b` minute bar, `d` daily bar, `u` updated bar, `s` trading status (halt/resume), `l` LULD, `c` correction, `x` cancel/error, `i` imbalance; control: `success`, `error`, `subscription`. Subscribing to `trades` auto-adds `corrections` + `cancelErrors`.
 
 **WebSocket lessons:**
-- **One concurrent connection per key** on most plans — a 2nd connection → `{"code":406,"connection limit exceeded"}`. Centralize the stream in **one process** and fan out to your own clients (don't open a socket per user).
+- **Connection limits are per correspondent, shared by every process you run** — Broker plans allow **5** concurrent streams (Standard, StandardPlus3000, StandardPlus5000) or **10** (StandardPlus10000). Exceeding it → `[{"T":"error","code":406,"msg":"connection limit exceeded"}]`. Centralize the stream in **one process** and fan out to your own clients (don't open a socket per user).
 - Authenticate within **10s** or get dropped (`404`).
 - Other error codes: `401` not auth'd, `402` auth failed, `405` symbol limit, `407` slow client, `409` insufficient subscription (feed not entitled), `410` invalid action for feed.
 - Messages are **batched** — always iterate the array; don't assume one frame = one event.
@@ -108,7 +108,7 @@ Real-time and historical US equity data. Unlike the Broker endpoints, market dat
 
 Use the host-appropriate path (see the table in §1): `/v2/...` on the Trading API host, `/v1/...` on the Broker API host.
 
-- **Assets** (`GET /v2/assets` on Trading host · `GET /v1/assets` and `/v1/assets/{symbol}` on Broker host) — tradability metadata: `tradable`, `fractionable`, `marginable`, `shortable`, `borrow_status` (replaces deprecated `easy_to_borrow`), `status` (`active`/`inactive`), `class` (`us_equity`/`us_option`/`crypto`/`ipo`), `exchange`, `attributes[]` (e.g. `has_options`, `overnight_tradable`). Filter by `status`, `asset_class`, `exchange`. **Cache this** — it changes slowly; query it before trading to confirm `tradable`/`fractionable` (see `alpaca-broker-trading-orders`).
+- **Assets** (`GET /v2/assets` on Trading host · `GET /v1/assets` and `/v1/assets/{symbol}` on Broker host) — tradability metadata: `tradable`, `fractionable`, `marginable`, `shortable`, `borrow_status` (replaces deprecated `easy_to_borrow`), `status` (`active`/`inactive`), `class` (`us_equity`/`us_option`/`crypto`/`ipo`), `exchange`, `attributes[]` (e.g. `has_options`, `overnight_tradable`). Filter Broker `/v1/assets` by `status`, `asset_class`, `attributes` — there is **no `exchange` filter** there; Trading `/v2/assets` adds `exchange`. **Cache this** — it changes slowly; query it before trading to confirm `tradable`/`fractionable` (see `alpaca-broker-trading-orders`).
 - **Clock** (`/v2/clock` on Trading host · `/v1/clock` on Broker host) — `is_open`, `next_open`, `next_close`, `timestamp`. Use this to gate market-hours logic instead of hardcoding 9:30–16:00 ET.
 - **Calendar** (`/v2/calendar` on Trading host · `/v1/calendar` on Broker host — note there is no `/v2/calendar` on the Broker host) — per-day `open`/`close` (`HH:MM`), `session_open`/`session_close` (`HHMM`, extended hours), `settlement_date`. **Use the calendar for holidays** — a naive "weekdays only" check runs jobs on market holidays (harmless but wasteful) and miscomputes "previous trading day."
 

--- a/skills/broker-api/money-precision/SKILL.md
+++ b/skills/broker-api/money-precision/SKILL.md
@@ -26,13 +26,13 @@ Alpaca returns prices, quantities, notional, and money amounts as **JSON strings
 
 ## 2. Round/truncate before sending — and know the direction
 
-Alpaca generally accepts **2 decimal places for cash** amounts and up to **9 for fractional share `qty`/`notional`**. If you send more precision than allowed, you risk rejection or silent rounding on their side.
+Orders take **up to 2 decimal places for `notional` and 9 for `qty`** (Broker API FAQ; the order schema's "2 decimal points" on `qty` is stale). Journal `amount` has no documented precision limit — send cash at 2 dp anyway (§3).
 
 **Rule:** explicitly round/truncate to the target precision *before* the API call, using a deliberate rounding mode.
 
-- For **money you're moving out / charging**, **truncate (round down)** to 2 dp so you never move more than intended. (e.g. `floor(amount * 100) / 100`.)
+- For **money you're moving out / charging**, **truncate (round down)** to 2 dp so you never move more than intended (e.g. `floor(amount * 100) / 100`). This is house policy, not an API constraint, and it applies to cash only — never truncate a share `qty` this way.
 - Pick the rounding mode consciously (`ROUND_DOWN` vs `ROUND_HALF_UP`) — don't inherit whatever the default float formatting does.
-- Re-round after every arithmetic step that could reintroduce precision (e.g. computing `amount * percentage` for a split allocation), not just at the end.
+- Carry full precision through the arithmetic and round **once**, at the boundary where the value is sent or displayed. Rounding intermediates compounds error.
 
 ```
 # splitting a deposit across holdings — round each slice down, track remainder
@@ -41,13 +41,13 @@ slice = truncate(total * (pct / 100), 2)
 
 ## 3. Fractional shares
 
-- `qty` and `notional` support up to **9 decimal places**.
+- `notional` takes 2 decimal places, `qty` takes 9. Round each to its own limit before sending.
 - `qty` XOR `notional` — never both (see `alpaca-broker-trading-orders`).
 - Don't reconstruct `qty` from `notional / price` and send it — pass `notional` and let Alpaca compute the fill. Round-tripping through a price you fetched introduces drift.
 
 ## 4. Storage
 
-- Store money in your DB as **fixed-point decimal**, not float. A practical pattern is generous precision/scale, e.g. `DECIMAL(20, 8)` — wide enough for multi-currency and fractional, with headroom beyond Alpaca's 2-dp cash so you never lose data you received.
+- Store money in your DB as **fixed-point decimal**, not float, with a scale at least as wide as the widest field you receive — scale ≥ 9 for `qty`, so the 9-dp fractional case can't silently truncate.
 - **Store what Alpaca sent verbatim** alongside any converted/derived values. If you truncate to 2 dp for the API call but received more precision back, keep both — it makes reconciliation and audits possible.
 - Keep an explicit **currency** column; Alpaca is multi-currency on some rails (funding wallet) even though most is USD.
 
@@ -61,8 +61,8 @@ slice = truncate(total * (pct / 100), 2)
 - [ ] Money fields parsed from strings into a **decimal** type; serialized back to strings.
 - [ ] **No binary floats** anywhere in the move-money path.
 - [ ] Amounts rounded/truncated to the allowed precision **before** the call, with an intentional rounding mode (round *down* for outgoing money).
-- [ ] Re-round after each intermediate computation.
-- [ ] DB columns are fixed-point decimal with headroom; raw Alpaca values stored verbatim.
+- [ ] Full precision carried through arithmetic; rounded once at the send/display boundary.
+- [ ] DB columns are fixed-point decimal with scale ≥ 9; raw Alpaca values stored verbatim.
 - [ ] Explicit currency tracked.
 
 **Related skills:** order qty/notional rules → `alpaca-broker-trading-orders`; journal/transfer amounts → `alpaca-broker-journals`, `alpaca-broker-funding-transfers`; reconciling stored vs Alpaca values → `alpaca-broker-reconciliation-idempotency`.

--- a/skills/broker-api/rate-limits-resilience/SKILL.md
+++ b/skills/broker-api/rate-limits-resilience/SKILL.md
@@ -20,30 +20,34 @@ Alpaca returns standard headers:
 | `X-RateLimit-Reset` | **unix timestamp (seconds)** when the window resets |
 
 **Parse them on every response, not just on errors.** Two uses:
-- **Proactive:** when `Remaining` drops below a threshold (e.g. ≤ 50), log a warning and/or slow down — you're about to get throttled.
+- **Proactive:** slow down as `Remaining` falls toward zero, rather than waiting to be throttled. Any warning threshold you pick is your own starting point, derived from `Limit` — Alpaca publishes none.
 - **Reactive:** on `429`, use `Reset` to wait exactly until the window opens.
 
-> Limits vary by endpoint and plan; market-data limits differ from broker limits. Don't hardcode a number — react to the headers.
+> Broker limits are applied at the **correspondent level** — across your whole integration, not per end-user account, so every process you run shares one budget. They're set per partner and not published; react to the headers.
+
+> **Sandbox limits are significantly lower than production** and are not a reliable signal of production headroom. Alpaca explicitly says **not to load-test against sandbox** — mock the Alpaca calls instead and have the stub simulate latencies sampled from real production calls.
 
 ## 2. The retry loop (pseudocode)
 
 ```
 MAX_ATTEMPTS = 10
 INITIAL_DELAY_MS = 1000
+MAX_DELAY_MS = 60000
+backoff(n) = min(INITIAL_DELAY_MS * 2^(n-1), MAX_DELAY_MS) + random(0, 500)
 
 for attempt in 1..MAX_ATTEMPTS:
     res = http(request)                      # with a sane timeout (see §5)
-    remaining, reset_at = parse_rate_headers(res.headers)
-    if remaining <= 50: log_warn("approaching rate limit", reset_at)
+    limit, remaining, reset_at = parse_rate_headers(res.headers)
+    if remaining < low_water(limit): log_warn("approaching rate limit", reset_at)
 
     if res.status == 429:
         # wait until the window resets, plus a small buffer
-        wait = (reset_at - now()) if reset_at else INITIAL_DELAY_MS * 2^(attempt-1)
-        sleep(max(0, wait) + 1000)           # +1s buffer past reset
+        wait = (reset_at - now()) if reset_at else backoff(attempt)
+        sleep(max(0, wait) + 1000 + random(0, 500))
         continue
 
     if res.status in (500, 502, 503, 504) or network_error:
-        sleep(INITIAL_DELAY_MS * 2^(attempt-1))   # exponential backoff
+        sleep(backoff(attempt))
         continue
 
     return res                                # success or non-retryable 4xx
@@ -51,16 +55,16 @@ raise last_error
 ```
 
 Key points:
-- **On `429`, wait until `X-RateLimit-Reset` + a ~1s buffer** — don't blindly exponential-backoff when the API told you exactly when to retry.
-- **Exponential backoff** (`base * 2^(attempt-1)`) for network errors and 5xx. With base 1s and 10 attempts the tail is minutes — fine for background jobs, too slow for user-facing calls (use fewer attempts there).
+- **On `429`, wait until `X-RateLimit-Reset` + a ~1s buffer**, then keep exponential backoff underneath — `Reset` says when the window rolls, not whether the herd behind you re-saturates it.
+- **Exponential backoff** (`base * 2^(attempt-1)`) for network errors and 5xx, **capped** (the docs' example caps at 60s). With base 1s and 10 attempts the tail is minutes — fine for background jobs, too slow for user-facing calls (use fewer attempts there).
+- **Jitter every wait.** It's part of the documented recommendation, not an extra: a correspondent-wide limit means all your workers are throttled together and would otherwise retry in lockstep.
 - **Don't retry non-retryable 4xx** (`400`/`403`/`422`) — those won't fix themselves; surface them.
-- Optionally add **jitter** to backoff to avoid thundering-herd when many workers retry together.
 
 ## 3. Bounded concurrency
 
 Parallelism speeds bulk jobs but is the fastest way to hit limits. Use a **fixed worker pool**, not unbounded fan-out.
 
-- Start small (e.g. **5–8 concurrent requests**) and tune against the rate-limit headers. A real lesson from production: a pool was *reduced* from 10 → 5 to ease both Alpaca and downstream-DB load.
+- **Size the pool from `X-RateLimit-Limit`**, not from a fixed number, and remember the limit is correspondent-level: every worker, cron job, and web process you run draws on the same budget. Tune down from observed `Remaining`; your own downstream store is often the tighter constraint.
 - Cache per-entity reads **within a run** (e.g. an account's buying power, or a per-account transfer list) so you don't refetch the same thing across items in a batch.
 - For per-item throttling, a small fixed sleep between calls (e.g. 100ms) is a crude-but-effective floor when you can't easily coordinate a pool.
 
@@ -68,7 +72,7 @@ Parallelism speeds bulk jobs but is the fastest way to hit limits. Use a **fixed
 
 List endpoints page forward with a token — never assume one response is complete.
 
-- **Activities** (`/v1/accounts/activities`): page via the `X-Next-Page-Token` response header; loop until it's empty. Use `page_size` (≤100) and a `direction`.
+- **Activities** (`/v1/accounts/activities`): the response is a **bare JSON array** with no pagination header — pass the **`id` of the last activity in the page** back as `page_token` and stop when a page comes back short. `page_size` defaults to and maxes at 100 (no maximum when `date` is set — it returns everything); `direction` is `asc`/`desc`, default `desc`.
 - **Market-data bars** (`/v2/stocks/bars`): page via `next_page_token` in the body → pass back as `page_token`. Remember `limit` counts across all symbols and results sort by symbol-then-time, so **a single page may contain only the first symbol(s)** — keep paging.
 - Wrap each page fetch in the retry loop from §2.
 
@@ -77,21 +81,26 @@ token = null
 loop:
     page = fetch(url + (token ? "&page_token="+token : ""))   # via retry loop
     accumulate(page.items)
-    token = page.next_token            # header or body, per endpoint
-    if not token: break
+    if body_token_endpoint:
+        token = page.next_page_token
+        if not token: break
+    else:                              # activities: bare array, no token
+        if len(page.items) < page_size: break
+        token = page.items[-1].id
 ```
 
 ## 5. Timeouts & batch sizing
 
-- **Always set an HTTP timeout** (e.g. 15–30s). A hung connection without a timeout stalls a whole worker pool. (SSE streams are the exception — they're meant to stay open; see `alpaca-broker-sse-events`.)
+- **Always set an HTTP timeout** (15–30s is a reasonable starting point, not an Alpaca number). A hung connection without a timeout stalls a whole worker pool. (SSE streams are the exception — they're meant to stay open; see `alpaca-broker-sse-events`.)
 - Use a **shared HTTP client / connection pool** rather than constructing one per request, so keep-alive and connection reuse work.
-- When writing reconciliation results to your own store, **chunk bulk inserts** (e.g. 500 rows per statement) to stay under DB statement-size limits and keep transactions reasonable.
+- **Detect silence on the market-data WebSocket and reconnect + resubscribe.** A slow client is disconnected, and the `407 slow client` error is "not guaranteed to arrive before you are disconnected" — so a dead socket can look identical to a quiet one (see `alpaca-broker-market-data`).
+- When writing reconciliation results to your own store, **chunk bulk inserts** to stay under DB statement-size limits and keep transactions reasonable; pick the chunk size from your own database's behavior.
 
 ## 6. Resilience checklist for a bulk/cron job
 
 - [ ] Rate-limit headers parsed every response; proactive warn near the limit.
 - [ ] `429` → wait until `X-RateLimit-Reset` + buffer.
-- [ ] Exponential backoff (+ jitter) for 5xx/network; capped attempts.
+- [ ] Exponential backoff with jitter for 5xx/network; capped delay and capped attempts.
 - [ ] Non-retryable 4xx surfaced, not retried.
 - [ ] Bounded worker pool; per-run caching of repeated reads.
 - [ ] Pagination loop until the token is empty.

--- a/skills/broker-api/reconciliation-idempotency/SKILL.md
+++ b/skills/broker-api/reconciliation-idempotency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpaca-broker-reconciliation-idempotency
-description: Keep local state correct against the Alpaca Broker API — idempotency keys, ID-keyed upserts, event snapshotting and dedup, polling rails that have no events, nightly reconciliation/heal jobs, status state-machine mapping, and handling eventual consistency and corrections. Use when designing the data-correctness layer of any Alpaca integration in any language.
+description: Keep local state correct against the Alpaca Broker API — idempotency keys, ID-keyed upserts, event snapshotting and dedup, polling rails that have no events, windowed reconciliation/heal jobs, status state-machine mapping, and handling eventual consistency and corrections. Use when designing the data-correctness layer of any Alpaca integration in any language.
 ---
 
 # Alpaca — Reconciliation & Idempotency
@@ -36,30 +36,30 @@ Every money/order write must be safe to retry, because you can't tell a timeout 
 
 Events are **at-least-once**: replay cursors, reconnects, and corrections all cause the same event to arrive more than once.
 
-- **Snapshot-first, keyed on `event_id`.** Insert the raw event with upsert / skip-on-duplicate on `event_id` (a ULID). A duplicate becomes a no-op. This single unique constraint is your dedup boundary.
+- **Snapshot-first, keyed on the dedup id.** Insert the raw event with upsert / skip-on-duplicate so a duplicate becomes a no-op. Pick the key carefully: `event_id` (a ULID) is the **replay cursor**, and on the Activity SSE the **dedup key is `ref_id`**, the documented key for at-least-once redelivery on replay and for correction/bust linkage via `previous_id`. On the legacy status streams `event_id` fills both roles.
 - **Key business records on the Alpaca ID**, not on a local autoincrement, with upsert semantics.
 - **Guard transitions by current status.** Before acting, check the record isn't already terminal — so a duplicate "executed"/"filled" doesn't re-fire a payout or notification.
-- **Lock the row** while mutating (`SELECT … FOR UPDATE` or your engine's equivalent) so concurrent events for one record serialize.
+- **Serialize mutations per record.** Partitioning the consumer by `account_id` is the simplest default, since Alpaca guarantees per-account event ordering; a `SELECT … FOR UPDATE` row lock or an optimistic version column are the alternatives.
 - **Advance the cursor only after success** (at-least-once, made safe by the above).
 
 ## 4. Layer 3 — Reconciliation / heal jobs
 
 A scheduled job that re-pulls authoritative state from Alpaca and upserts it locally. This is what makes the system **self-healing**.
 
-**Canonical nightly heal (lesson):**
-1. For each active account, page through **trade activities** and **non-trade activities** (`GET /v1/accounts/activities`, paginated) for the last *N* days (e.g. 3) — a moving window that re-covers recent days so anything missed by SSE gets backfilled.
+**Canonical windowed heal (lesson):**
+1. Re-read **activities** from the Activity SSE (`GET /v2beta1/events/activities`) with `since`/`until` bounds. Bounded replay is a batch job, not a subscription: the stream ends with a `200` once it reaches `until`, and `since`/`until` filter on business time (`at`). (`GET /v1/accounts/activities` is marked fully replaced, but it is still the only source for activities booked before **2026-02-11**; use it for any window that reaches back past that date.)
 2. Page through **journals** (`GET /v1/journals`) and **transfers** for the same window.
 3. **Upsert** each into your tables keyed on the Alpaca ID (insert-or-update). Re-running is safe and converges.
 4. Bound concurrency (a small worker pool) and respect rate limits (`alpaca-broker-rate-limits-resilience`).
 
-Why a *window* and not just "since last run": it absorbs corrections, late settlements, and any events dropped during a deploy — without rescanning all history every night.
+Why a *window* and not just "since last run": it absorbs corrections, late settlements, and any events dropped during a deploy — without rescanning all history every night. Choose a window longer than your longest plausible outage.
 
 ## 5. Polling the rails that have no events
 
 Not everything emits SSE. Where there's no event, you **must poll**.
 
 - **Funding-wallet per-transfer status** (v1beta) is not pushed — poll `GET /v1beta/.../funding_wallet/transfers/{id}` on a schedule.
-- Stagger pollers (e.g. one rail at `:00`, another at `:30`) to spread API load.
+- Stagger pollers across the interval so the rails don't all fire together and spike API load.
 - **Only poll records in a non-terminal state.** Filter your query to `status IN (pending, processing, …)`; once a record reaches a terminal status, drop it from the polling set. This bounds the work and prevents re-notifying.
 - **Gotcha — no GET-by-id on classic wire transfers:** you must `GET /v1/accounts/{id}/transfers?direction=OUTGOING` (a *list*) and match the ID client-side; cache the list per account within a run.
 
@@ -69,8 +69,9 @@ Not everything emits SSE. Where there's no event, you **must poll**.
 
 Alpaca exposes several status enums (account, order, journal, transfer, funding-wallet) — each with its own vocabulary. Don't scatter raw Alpaca strings through your app.
 
-- **Define one explicit mapping table** per domain from Alpaca status → your internal status (e.g. `executed`/`COMPLETE` → `COMPLETED`; `rejected`/`canceled`/`returned`/`failed` → `CANCELLED`).
-- **Handle unknown statuses gracefully** — log and skip, never crash. Alpaca adds values (and has shipped bad ones — e.g. a stray `TRD` activity type that consumers had to filter out).
+- **Define one explicit mapping table** per domain from Alpaca status → your internal status (e.g. transfer `COMPLETE` → `COMPLETED`; `REJECTED`/`CANCELED`/`RETURNED` → `CANCELLED`).
+- **Casing and membership are not uniform.** Transfer statuses are UPPERCASE and include `RETURNED`; there is no `failed`. Journal statuses are lowercase. The REST `TransferStatus` enum and the funding-event enum aren't even the same set, so map the union of both.
+- **Handle unknown statuses gracefully** — log and skip, never crash. Alpaca adds values over time.
 - **Know which states are terminal** (they differ per enum) so you stop polling/processing them.
 
 ## 7. Eventual-consistency hazards to design for
@@ -82,7 +83,7 @@ Alpaca exposes several status enums (account, order, journal, transfer, funding-
 
 ## 8. Anti-patterns (seen in the wild)
 
-- ❌ Reconnecting an SSE stream **without** a `since_id` cursor → silently drops every event during the gap. (Fix: persist + replay the cursor.)
+- ❌ Reconnecting an SSE stream **without** a since cursor (`since_id` on v2, `since_ulid` on v1) → silently drops every event during the gap. (Fix: persist + replay the cursor.)
 - ❌ Treating an SSE stream as your *only* source → no backstop for missed events. (Fix: add the heal job.)
 - ❌ Blind retry of a journal/order without an idempotency key → double money movement.
 - ❌ Acting on `executed` as irreversible → broken books when a reversal/correction lands.
@@ -94,7 +95,7 @@ Alpaca exposes several status enums (account, order, journal, transfer, funding-
 WRITE:   local intent row (idempotency key) → Alpaca call → store Alpaca ID
 LIVE:    SSE consumer (cursor-replay, snapshot-keyed dedup, status-guarded upsert)
 POLL:    schedulers for rails with no events (non-terminal records only)
-HEAL:    nightly window re-pull of activities/journals/transfers → upsert
+HEAL:    windowed re-pull of activities/journals/transfers → upsert
 MAP:     Alpaca status → internal status, terminal-aware, unknown-tolerant
 ```
 

--- a/skills/broker-api/sse-events/SKILL.md
+++ b/skills/broker-api/sse-events/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpaca-broker-sse-events
-description: Consume Alpaca Broker API real-time event streams over Server-Sent Events (SSE) — account status, journal, transfer/funding, trade, and non-trade-activity events — reliably. Covers connection, auth, replay cursors (since/since_id), heartbeats, reconnection/backoff, ordering, and idempotent processing. Use when building an event consumer for Alpaca lifecycle events in any language.
+description: Consume Alpaca Broker API real-time event streams over Server-Sent Events (SSE) — account status, journal, transfer/funding, trade, and non-trade-activity events — reliably. Covers connection, auth, replay cursors (since / since_id / since_ulid), heartbeat and comment lines, reconnection/backoff, ordering, and idempotent processing. Use when building an event consumer for Alpaca lifecycle events in any language.
 ---
 
 # Alpaca Broker API — Real-Time Events (SSE)
@@ -25,13 +25,15 @@ SSE is plain HTTP. You don't need a special client: open a GET, keep the connect
 | Journal status | `GET /v2/events/journals/status` | JNLC/JNLS lifecycle (`queued`→`executed`, `correct`…) |
 | Funding/transfer status | `GET /v2/events/funding/status` | Unified: `Transfer`, `BankRelationship`, `WireBank`, `FundingWallet` entities (switch on `entity_type`) |
 | Trade updates | `GET /v2/events/trades` | Order events in the `event` field: `new`, `fill`, `partial_fill`, `canceled`, `rejected`, `held`, `trade_bust`, `trade_correct`… (richer than order `status`) |
-| Non-trade activities | `GET /v1/events/nta` | Dividends, interest, fees, splits, ACATs, cash disbursements. `entry_type` e.g. `JNLC`/`FEE`/`INT`/`DIVNRA`/`CSD`; `status` ∈ `executed`/`correct`/`canceled` |
+| Activities | `GET /v2beta1/events/activities` | Every financial activity in one stream: fills, corporate actions, fees, journals, transfers. `activity_type` (`TRD` = trade fill) + `activity_subtype` + a `details` object; ULID `event_id`, UUID `ref_id` |
+| Non-trade activities (legacy) | `GET /v1/events/nta` | Dividends, interest, fees, splits, ACATs, cash disbursements. `entry_type` e.g. `JNLC`/`FEE`/`INT`/`DIVNRA`/`CSD`; `status` ∈ `executed`/`correct`/`canceled` |
 
 > **Paths & versions are NOT uniform — verify each.** This is exactly the kind of cross-stream inconsistency Alpaca's docs under-communicate:
-> - **`/v2`** streams (trades, journals/status, funding/status) use a **ULID** `event_id` directly; `/v1/events/trades` and `/v1/events/journals/status` are *legacy* (existing partners only — migrate to v2). `/v2/events/trades` was previously `/v2beta1`, now redirected.
-> - **`/v1`** streams (accounts/status, nta) are **current, not deprecated** — there is no v2 yet. Each event carries **both** an integer `event_id` *and* a ULID `event_ulid`.
+> - **The Activity SSE fully replaces `/v1/events/nta` and `GET /v1/accounts/activities`** for activities booked after **2026-02-11**; older history still needs the REST endpoint. New partners should not use the legacy endpoints. It does **not** replace `/v2/events/trades`: fills, corrections and busts appear on both, but non-fill lifecycle events (`accepted`, `canceled`, `expired`, `replaced`) are not activities and never appear on it.
+> - **`/v1/events/trades` is gone** (fully deprecated, no longer available). `/v1/events/journals/status` is legacy — migrate to `/v2`.
+> - **`/v1`** events carry an integer `event_id` *and* a ULID `event_ulid`; **`/v2`/`/v2beta1`** carry a ULID `event_id`. §4 says which cursor to pass.
 >
-> Every event carries `at` (timestamp), `account_id`, and `status_from`/`status_to` (account/journal/funding) or `event`+`order` (trades).
+> Field shapes differ per stream — there is no universal envelope. Check each schema.
 
 ## 3. Connection
 
@@ -50,55 +52,57 @@ Every stream supports point-in-time replay:
 
 | Param | Meaning |
 |-------|---------|
-| `since` / `until` | Date or RFC3339 timestamps. **URL-encode `+`** in offsets as `%2B`. |
-| `since_id` / `until_id` | ID cursors. On **v2** streams the ID *is* a ULID. On **v1** streams it's the **integer** `event_id`. |
-| `since_ulid` / `until_ulid` | **v1 streams only** (accounts, nta) — ULID-based cursors, since v1 events carry both an int `event_id` and a `event_ulid`. |
+| `since` / `until` | RFC3339 or `YYYY-MM-DD` timestamps (date-only on some `/v1` streams). **URL-encode `+`** in offsets as `%2B`. |
+| `since_id` / `until_id` | **v2 / v2beta1 streams — ULID values.** On `/v1/events/*` these are the *legacy integer* cursors: available only to select broker partners and sunset **2027-02-15**. Don't build on them. |
+| `since_ulid` / `until_ulid` | **v1 streams** (accounts/status, nta, and the legacy `/v1` journals stream) — the ULID cursors, available to all partners. Use these on v1; they don't exist on v2. |
 
-Rules: `since` is required if `until` is set; `since_id` required if `until_id` set (same for `since_ulid`/`until_ulid`); you **can't mix** `since`, `since_id`, and `since_ulid`. **Without any since cursor, no history is returned** — you only get live pushes from now on. Reaching the `until` bound ends the stream with a `200`.
+Rules: `since` is required if `until` is set; `since_id` required if `until_id` set (same for `since_ulid`/`until_ulid`); you **can't mix** `since`, `since_id`, and `since_ulid`. On `/v2beta1/events/activities` the dependency flips: **`since` requires `until`**, and only `since_id` can be left open-ended for live tailing. **Without any since cursor, no history is returned** — you only get live pushes from now on. Reaching the `until` bound ends the stream with a `200`.
 
-**This is the single most important reliability lesson:** persist the ID of the last event you *successfully processed*. On every (re)connect, pass it as your since cursor (`since_id` on v2; `since_ulid` or `since_id` on v1) so Alpaca replays anything you missed during the gap. A consumer that reconnects **without** a cursor silently drops every event that occurred while it was down.
+**This is the single most important reliability lesson:** persist the ID of the last event you *successfully processed*. On every (re)connect, pass it as your since cursor — **`since_id` on v2/v2beta1, `since_ulid` on v1** — so Alpaca replays anything you missed during the gap. A consumer that reconnects **without** a cursor silently drops every event that occurred while it was down.
 
 ## 5. Ordering caveat
 
-Within a millisecond, ULIDs contain a random component, so two events in the same millisecond can sort either way. Alpaca's own guidance: **for reconciliation, restart the stream from a `since` a few minutes before your last event** and rely on idempotent processing to absorb the overlap. Don't assume strict total ordering — assume *approximate* ordering plus dedup.
+Within a millisecond, ULIDs contain a random component, so two events in the same millisecond can sort either way. Alpaca's own guidance: **for reconciliation, restart the stream from a `since` a few minutes before your last event** and rely on idempotent processing to absorb the overlap. Alpaca guarantees ordering **per account**; across accounts it guarantees nothing. So assume *approximate* global ordering plus dedup — and exploit the per-account guarantee (see §7).
 
 ## 6. Reliability patterns (hard-won)
 
 SSE connections drop — networks, load balancers, deploys, and Alpaca-side resets all happen. A production consumer needs:
 
-1. **Heartbeat / silence detection.** SSE has no application heartbeat by default. Track `lastMessageAt` on every frame; if the stream is silent past a threshold (e.g. 5 min), proactively tear down and reconnect — a dead socket often looks "open."
-2. **Reconnect with exponential backoff + cap.** On error/close, reconnect after a delay that doubles up to a ceiling (e.g. start 1s, cap 60s). Reset the delay on a successful connect.
-3. **A single-reconnect guard.** Use a flag so an error storm doesn't spawn many concurrent reconnect attempts racing each other.
-4. **Always reconnect with `since_id`** = last processed event (see §4).
-5. **Process idempotently** (see §7) — overlap from replay is expected, not exceptional.
-6. **Don't let a side-effect failure kill the stream.** Wrap per-event processing in try/catch; log and continue. One bad event (or a downstream outage) must not stop you consuming the rest.
+1. **Parse comment lines — never discard them.** Any `:`-prefixed line is an SSE comment, and Alpaca carries three meanings there: `:heartbeat` (alive, no action); `: you are reading too slowly, dropped N messages` (**silent data loss** — treat it as a gap and re-replay from your cursor); `: internal server error` (server is closing — reconnect; v2/v2beta1 streams only). A consumer that filters `:` lines loses data without noticing.
+2. **Silence detection.** Track `lastMessageAt` on every frame, heartbeats included; if the stream goes quiet for a small multiple of the heartbeat cadence you observe, tear down and reconnect — a dead socket often looks "open." The cadence isn't documented, so measure it rather than hardcoding a timeout.
+3. **No blocking I/O in the reader loop.** Alpaca's explicit guidance: read into a queue, process on a worker. A synchronous DB write per event is what earns you the `dropped N messages` comment.
+4. **Reconnect with exponential backoff + cap.** On error/close, reconnect after a delay that doubles up to a ceiling (e.g. start 1s, cap 60s). Reset the delay on a successful connect.
+5. **A single-reconnect guard.** Use a flag so an error storm doesn't spawn many concurrent reconnect attempts racing each other.
+6. **Always reconnect with your cursor** = last processed event (`since_id` on v2, `since_ulid` on v1; see §4).
+7. **Process idempotently** (see §7) — overlap from replay is expected, not exceptional.
+8. **Don't let a side-effect failure kill the stream.** Wrap per-event processing in try/catch; log and continue. One bad event (or a downstream outage) must not stop you consuming the rest.
 
 > Note: OpenAPI can't fully model SSE, so **generated API clients often hang** on these endpoints (waiting for a response that never ends). Use a real streaming HTTP/SSE client, not a codegen'd one.
 
 ## 7. Idempotent processing pipeline
 
-The robust shape for each event:
+The robust shape for each event, run on a worker rather than in the reader loop (§6):
 
 ```
-parse → persist a raw event snapshot (keyed on event_id, skip-if-exists)
+parse → persist a raw event snapshot (keyed on the dedup id, skip-if-exists)
       → match the local record by Alpaca ID (account_id / journal_id / order_id / transfer_id)
-      → update local state under a row lock / guarded by current status
+      → update local state guarded by current status, serialized per record
       → fire side effects (notifications, downstream transfers)
       → advance the stored cursor to this event_id
 ```
 
-- **Snapshot-first, keyed on `event_id`.** Insert the raw event with an upsert/skip-duplicate on `event_id`. A duplicate (from replay or an at-least-once redelivery) is then a no-op. This is your dedup boundary.
-- **Lock the target row** (`SELECT … FOR UPDATE` or equivalent) when mutating a transfer/order so two events for the same record can't race.
+- **Keep the two ids apart.** `event_id` is the *replay cursor*; the *dedup key* is the business id. On the Activity SSE that's `ref_id` (execution id for trades, transaction id otherwise): replay redelivers events at-least-once, and corrections/busts link back through `previous_id`, so `ref_id` is the documented dedup key. Backfilled activities arrive late, at the end of the `event_id` sequence, with their original `at`. On the legacy status streams `event_id` is both.
+- **Serialize mutations per record** so two events for one transfer/order can't race. Partitioning workers by `account_id` is the simplest default and is what the per-account ordering guarantee (§5) buys you; a `SELECT … FOR UPDATE` row lock or an optimistic version column are alternatives.
 - **Guard transitions by current status** — e.g. only act on a transfer that isn't already in a terminal state, so a late/duplicate "executed" doesn't re-trigger a payout.
 - **Advance the cursor only after successful processing**, so a crash mid-event replays it rather than skipping it (at-least-once, which idempotency makes safe).
 
 ## 8. Per-stream notes
 
-- **Account status:** drive onboarding UI and "enable trading" off `status_to == ACTIVE`. Reject sandbox/paper account IDs in live handlers.
+- **Account status:** drive onboarding UI and "enable trading" off `status_to == ACTIVE`.
 - **Trade updates:** `new`/`accepted`/`pending_new` are pre-fill; update local order state on `fill`/`partial_fill`/`canceled`/`rejected`. Invalidate any cached portfolio/holdings on fills.
 - **Journals:** remember `executed` isn't final and `correct` spawns a *new* journal ID (see `alpaca-broker-journals`). Idempotency + ID-keyed snapshots absorb both.
-- **Funding/transfer:** unified stream across 4 entity types; switch on `entity_type`. Funding-wallet *per-transfer* status may still need polling (`alpaca-broker-funding-transfers`).
-- **NTA:** dividends/fees/interest/corporate-actions — persist as activity snapshots; these feed balance/portfolio reconciliation.
+- **Funding/transfer:** unified stream across 4 entity types; switch on `entity_type`. Transfer statuses are **UPPERCASE** (`QUEUED`, `APPROVAL_PENDING`, `APPROVED`, `SENT_TO_CLEARING`, `COMPLETE`, `REJECTED`, `CANCELED`, `EXPIRED`, `RETURNED`), and the funding-event list differs from the REST `TransferStatus` enum — which adds `PENDING` and drops `EXPIRED` — so accept the union. Funding-wallet *per-transfer* status may still need polling (`alpaca-broker-funding-transfers`).
+- **Activities / NTA:** dividends/fees/interest/corporate-actions and fills — persist as activity snapshots keyed on `ref_id`; these feed balance/portfolio reconciliation. `previous_id` on an activity carries the corrected activity's `ref_id`.
 
 ## 9. SSE is necessary but not sufficient
 

--- a/skills/broker-api/trading-orders/SKILL.md
+++ b/skills/broker-api/trading-orders/SKILL.md
@@ -45,8 +45,8 @@ Schema-required: `type` and `time_in_force`. Conditionally required: `symbol`, `
 | Field | Values / notes |
 |-------|----------------|
 | `symbol` | required (except `mleg` multi-leg options) |
-| `qty` | decimal **string**, up to 9 dp. Fractional only for `market`+`day` |
-| `notional` | decimal **string**, up to 9 dp. **Mutually exclusive with `qty`** |
+| `qty` | decimal **string**, up to **9 dp**; fractionable only for `market`+`day` per the order schema |
+| `notional` | decimal **string**, up to **2 dp**. **Mutually exclusive with `qty`** |
 | `side` | `buy`, `sell` (plus advanced: `sell_short`, …) |
 | `type` | `market`, `limit`, `stop`, `stop_limit`, `trailing_stop` |
 | `time_in_force` | `day`, `gtc`, `opg`, `cls`, `ioc`, `fok` |
@@ -65,15 +65,15 @@ Schema-required: `type` and `time_in_force`. Conditionally required: `symbol`, `
 - **On by default** for all accounts (live + paper).
 - Asset must have **`fractionable: true`** (check the Assets API — see `alpaca-broker-market-data`), else `requested asset is not fractionable`.
 - **TIF must be `day`** for fractional/notional.
-- **Notional** is limited to `market` and `limit` (day); only `limit` for extended hours. Fractional `qty` additionally allows `stop`/`stop_limit` per the guide.
+- **Notional** is limited to `market` and `limit` (day); only `limit` for extended hours.
 - **No shorting fractional** — all fractional sells are marked long.
-- Precision: up to **9 decimal places** for both `qty` and `notional`.
+- Precision: **2 decimal places for `notional`, 9 for `qty`** (Broker API FAQ, "What is the precision for notional and qty"; the order schema's "2 decimal points" on `qty` is stale). Eligible types: the order schema says fractional `qty` only on `market`+`day`; the Fractional Trading guide also accepts `limit`/`stop`/`stop_limit` at TIF `day` — confirm in sandbox before relying on the wider set.
 
 ## 4. Order status lifecycle
 
 `OrderStatus` (the order object's `status`): `new`, `partially_filled`, `filled`, `done_for_day`, `canceled`, `expired`, `replaced`, `pending_cancel`, `pending_replace`, `accepted`, `pending_new`, `accepted_for_bidding`, `stopped`, `rejected`, `suspended`, `calculated`.
 
-> **Order `status` ≠ trade-event `event`.** The order object's `status` is the enum above. The **SSE trade-update stream** reports a *richer* `event` enum that adds operational events not present as a status — including `held` (multi-leg secondary legs awaiting trigger), `trade_bust`, `trade_correct`, `restated`, `order_cancel_rejected`, `order_replace_rejected`. So `held` exists as a trade *event* but never as an order *status*. See `alpaca-broker-sse-events`.
+> **Order `status` ≠ trade-event `event`.** The order object's `status` is the enum above. The **SSE trade-update stream** reports a *richer* `event` enum that adds operational events with no Broker order status — `trade_bust`, `trade_correct`, `restated`, `order_cancel_rejected`, `order_replace_rejected`. `held` is both: a trade event, and an `OrderStatus` in the **Trading API** enum though not in the Broker one, so don't assume the two enums match. See `alpaca-broker-sse-events`.
 
 **Terminal:** `filled`, `canceled`, `expired`, `rejected` (and `replaced` for the original order). **Everything else is in-flight.**
 
@@ -82,7 +82,7 @@ Schema-required: `type` and `time_in_force`. Conditionally required: `symbol`, `
 - `new` — received **and routed to exchanges**; the usual initial live state.
 - `pending_new` — routed but not yet accepted for execution (rare).
 
-So the typical opening sequence is `accepted → pending_new → new`, then fills. **Lesson:** treat `new`/`accepted`/`pending_new` as "exists but not done." Persist the order on submit, then update on fill/cancel/reject events — don't block the user waiting for a terminal state synchronously.
+An order usually reaches `new` directly; `accepted`/`pending_new` are rare intermediates. **Lesson:** treat `new`/`accepted`/`pending_new` as "exists but not done." Persist the order on submit, then update on fill/cancel/reject events — don't block the user waiting for a terminal state synchronously.
 
 ## 5. Positions & trading account
 
@@ -93,12 +93,14 @@ So the typical opening sequence is `accepted → pending_new → new`, then fill
 - Blockers: `trading_blocked`, `account_blocked`, `transfers_blocked`, `trade_suspended_by_user`.
 - `multiplier`, `regt_buying_power`, `non_marginable_buying_power`, `long_market_value`, `initial_margin`, `maintenance_margin`, `sma`.
 
-**Lesson — check buying power before notional orders.** For a "spend $X" UX, read `buying_power`/`cash` first and reject/notify on insufficient funds, rather than letting Alpaca reject the order. (Cache it per account within a batch run to avoid re-fetching.)
+**Lesson — check buying power before notional orders.** For a "spend $X" UX, read `buying_power`/`cash` first and reject/notify on insufficient funds, rather than letting Alpaca reject the order. Re-read it after every accepted order — each one consumes buying power.
 
-> **PDT/day-trade fields are deprecated** (since 2026-04-27, sunset 2026-07-06) following FINRA's intraday-margin rule change: `daytrade_count`, `pattern_day_trader`, `daytrading_buying_power`, `bod_dtbp`, plus config `dtbp_check`/`pdt_check`. They still exist in the schema today but stop relying on them.
+> **PDT/day-trade fields are gone** following FINRA's intraday-margin rule change: `daytrade_count`, `pattern_day_trader`, `daytrading_buying_power` and `bod_dtbp` are absent from the current `TradeAccount` schema, as are the `dtbp_check`/`pdt_check` configurations. Don't code against them.
 
 ## 6. Documented gotchas
 
+- **Minimum order value:** every buy order needs a market value of at least **$1** or it's rejected with `422`; sells are exempt.
+- **Per-asset-class rules:** options and crypto go through this same endpoint, gated by `asset_class` — crypto rejects `time_in_force: day` (only `gtc`/`ioc`) and allows only `market`/`limit`/`stop_limit`; options allow `day`/`gtc` only. Check the type/TIF matrix in the `OrderType`/`TimeInForce` descriptions at `https://docs.alpaca.markets/reference/createorderforaccount` rather than assuming the equity set.
 - **Wash-trade rejection (403):** if a user's two orders could self-cross (opposite sides, crossable prices), Alpaca rejects. Opposing market/stop pairs are always rejected; opposing limits rejected when buy-limit ≥ sell-limit. **Use `bracket`/`oco`/`trailing_stop` for simultaneous take-profit + stop-loss** — they're exempt.
 - **Bracket constraints:** requires both `take_profit.limit_price` and `stop_loss.stop_price`; TP must be above SL for a buy; no extended hours; TIF `day`/`gtc`; child legs activate only after the entry fully fills; canceling one cancels the group.
 - **Notional orders can't be replaced** — cancel and resubmit (IPO-class notional is the exception). Fractional `qty` can't be changed on replace ("full shares only").
@@ -108,7 +110,7 @@ So the typical opening sequence is `accepted → pending_new → new`, then fill
 ## 7. Idempotency & recurring-invest lessons
 
 - **Always set `client_order_id`** from your own transaction record. It's your dedup key and lets you look the order up (`orders:by_client_order_id`) if the create response is lost. Note it dedups *lookup*, not necessarily *replay* — combine it with a local "already-submitted?" guard.
-- **Recurring/scheduled buys (lesson):** the robust pattern is — fetch pending invest instructions from your DB → check buying power → place a `notional` `market`/`day` order per instruction → record the returned order → mark the instruction done **only after** a successful create. On insufficient funds, cancel the instruction and notify, don't silently skip. Schedule the batch shortly **before** market open and respect the market clock (`alpaca-broker-market-data`).
+- **Recurring/scheduled buys (lesson):** the robust pattern is — fetch pending invest instructions from your DB → check buying power → place a `notional` `market`/`day` order per instruction → record the returned order → mark the instruction done **only after** a successful create. On insufficient funds, skip this run and surface it; whether to cancel a standing instruction is a product decision. Schedule the batch shortly **before** market open and respect the market clock (`alpaca-broker-market-data`).
 - Track fills via the **trade events SSE stream**, not by polling each order — see `alpaca-broker-sse-events`.
 
 **Related skills:** prices/assets/clock → `alpaca-broker-market-data`; fills in real time → `alpaca-broker-sse-events`; rate limits on bulk placement → `alpaca-broker-rate-limits-resilience`; money formatting → `alpaca-broker-money-precision`.


### PR DESCRIPTION
## Summary
- Fix claims that produced broken code: activities pagination (last `id` as `page_token`, no header), SSE comment lines, replaced/removed v1 streams, `since_ulid` vs ULID `since_id` cursors, `ref_id` as the activity-stream dedup key
- Correct transfer, funding-wallet, onboarding, and journal status vocabularies
- Add Instant Funding, JNLC v2 and limits, and order precision per the Broker FAQ (2 dp `notional`, 9 dp `qty`)
- Drop lessons overfit to one integration or unsupported by docs

Every changed claim was verified against the live docs and OpenAPI specs. Auth changes are split out into #11, stacked on this PR.

## Type of change
- [ ] New skill
- [x] Improvement to existing skill
- [x] Bug fix
- [ ] Documentation / repo infrastructure

## Checklist
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] Skill lives under `skills/trading-api/` or `skills/broker-api/`
- [x] Skill `name` follows `alpaca-<product-scope>-<skill-name>` (`trading` or `broker`)
- [x] `SKILL.md` has `name` + `description` frontmatter
- [x] No API keys or secrets committed
- [ ] Disclosure language included for trading-related outputs (if applicable)
- [ ] Updated [README.md](../README.md) skills table (if adding or renaming a skill)

## Test plan
- [x] `python3 scripts/validate_skills.py` passes locally
- [x] CI `skill-check` workflow passes
