### PR TITLE
feat: lead broker auth with client-credentials tokens

### DIFF
--- a/skills/broker-api/account-onboarding/SKILL.md
+++ b/skills/broker-api/account-onboarding/SKILL.md
@@ -7,7 +7,7 @@ description: Open and manage brokerage accounts via the Alpaca Broker API — ac
 
 Create and manage end-user brokerage accounts under your firm. This is the **first** step of any Broker API integration: no funding, journaling, or trading can happen until an account reaches `ACTIVE`.
 
-> Read `alpaca-broker-integration` first for base URLs, auth, and conventions. This skill assumes **Broker API + HTTP Basic auth**.
+> Read `alpaca-broker-integration` first for base URLs and auth (client-credentials Bearer token; legacy Basic still works).
 
 ## Reference
 - Guide: `https://docs.alpaca.markets/docs/getting-started-with-broker-api`, `https://docs.alpaca.markets/docs/accounts`

--- a/skills/broker-api/funding-transfers/SKILL.md
+++ b/skills/broker-api/funding-transfers/SKILL.md
@@ -7,7 +7,7 @@ description: Move money between an Alpaca brokerage account and the EXTERNAL ban
 
 Getting cash into and out of end-user accounts. There are **three external rails** plus Instant Funding, and for the external rails the model splits cleanly into *bank links* (persistent) and *transfers* (the actual money movement).
 
-> Read `alpaca-broker-integration` first. Broker API + HTTP Basic auth. For moving cash *between* accounts in your omnibus (vs. to/from the outside world), see `alpaca-broker-journals` — that's a different mechanism.
+> Read `alpaca-broker-integration` first for base URLs and auth (client-credentials Bearer token; legacy Basic still works). For moving cash *between* accounts in your omnibus (vs. to/from the outside world), see `alpaca-broker-journals` — that's a different mechanism.
 
 ## Reference
 - Guide: `https://docs.alpaca.markets/docs/funding-accounts`

--- a/skills/broker-api/integration/SKILL.md
+++ b/skills/broker-api/integration/SKILL.md
@@ -31,7 +31,7 @@ This is the **router / overview** skill. It covers the things that are true acro
 | **Broker API** | Open & manage brokerage accounts on behalf of *your* end users (KYC, funding, journals, trading-for-accounts, documents, events). You are the broker-of-record's tech partner; you custody many sub-accounts under your firm. | Apps that onboard their own users and hold their assets (neobrokers, fintechs). |
 | **Trading API** | Trade a *single* account that belongs to the API-key holder. | Individual algo traders, bots. |
 | **Market Data API** | Real-time + historical prices, bars, quotes, trades, news, corporate actions, screener. REST and WebSocket. | Everyone. |
-| **Authentication API** | OAuth 2.0 flows for letting third parties act on an Alpaca account. | OAuth integrations. |
+| **Authentication API** | Issues access tokens: `client_credentials` for your own machine-to-machine calls, plus OAuth 2.0 flows for letting third parties act on an Alpaca account. | Every Broker partner; OAuth integrations. |
 
 **Decide first which family you're on — it changes the base URL, the auth, and the URL shape of every call.** The most common confusion: Broker API places orders at `/v1/trading/accounts/{account_id}/orders` (the account is in the path because you act *for* a user), whereas the standalone Trading API places orders at `/v2/orders` (implicitly *your own* account).
 
@@ -54,35 +54,39 @@ These skills focus primarily on the **Broker API**, because that's where the lif
 
 ## 3. Authentication
 
-Auth differs **by API family** — this trips people up constantly.
-
-### Broker API → HTTP Basic
+### Client credentials → Bearer token (Broker API, and Broker partners calling Market Data)
 
 ```
-Authorization: Basic base64("<API_KEY_ID>:<API_SECRET_KEY>")
+POST https://authx.alpaca.markets/v1/oauth2/token
+     (sandbox: https://authx.sandbox.alpaca.markets/v1/oauth2/token)
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&client_id=<CLIENT_ID>&client_secret=<CLIENT_SECRET>
 ```
 
-The same Basic credential authenticates Broker REST, Broker SSE event streams, and trading-on-behalf-of-accounts. Build the base64 token **once** at startup; don't recompute per request.
+The secret goes in the **body** (`client_secret_post`), not in an `Authorization` header. The response is `{"access_token": "…", "expires_in": 899, "token_type": "Bearer"}` — tokens are valid **15 minutes**. Send it as `Authorization: Bearer <token>`.
 
-### Market Data API → key/secret headers (or Basic in broker context)
+Documented for the Broker API, and for Broker partners calling Market Data over both REST and WebSocket. On the WebSocket the auth message uses the literal key `access_token`:
+```json
+{"action": "auth", "key": "access_token", "secret": "<ACCESS_TOKEN>"}
+```
+Not yet available for the Trading API.
+
+**Cache the token per process and refresh before expiry** — around 12 of the 15 minutes. Hold it behind one accessor that can refresh, not a startup constant. Treat a `401` on a long-lived call as *refresh and retry once* before treating it as bad credentials; whether an already-open SSE stream survives token expiry is not documented.
+
+### Legacy key/secret → still supported, and the only path for Trading API
 
 ```
 APCA-API-KEY-ID: <API_KEY_ID>
 APCA-API-SECRET-KEY: <API_SECRET_KEY>
 ```
 
-For the WebSocket data stream, you don't use headers — you send an auth message *after* connecting:
+Broker also accepts `Authorization: Basic base64("<API_KEY_ID>:<API_SECRET_KEY>")` on REST and SSE. The Trading API uses the `APCA-API-*` headers only. For the WebSocket data stream you don't use headers — you send an auth message *after* connecting:
 ```json
 {"action": "auth", "key": "<API_KEY_ID>", "secret": "<API_SECRET_KEY>"}
 ```
 
-> Broker API partners can usually authenticate market-data calls with their **Broker Basic** credentials too. Pick one scheme per data client and be consistent; mixing them is a frequent source of 401s.
-
-### Trading API → key/secret headers
-Same `APCA-API-*` headers as market data.
-
-### Authentication API → OAuth 2.0 Bearer
-For OAuth integrations, exchange the code for a token and send `Authorization: Bearer <token>`.
+> Pick one scheme per client and be consistent; mixing them is a frequent source of 401s.
 
 ---
 
@@ -96,7 +100,7 @@ Alpaca gives you three transports. Use the right one for the job — and know th
 | **SSE** | `text/event-stream` over a long-lived HTTPS GET | Broker lifecycle events: account status, journals, transfers, trades, non-trade activities. **Replayable** via cursors. | `alpaca-broker-sse-events` |
 | **WebSocket** | `wss://` | Real-time market data (trades/quotes/bars). | `alpaca-broker-market-data` |
 
-**Key distinction:** Broker *events* come over **SSE** (simple HTTP, Basic auth, replayable with `since` or `since_ulid`/`until_ulid` on v1 and `since_id` — a ULID — on v2; the v1 integer `since_id`/`until_id` are deprecated, select partners only, sunset 2027-02-15). Market *data* comes over **WebSocket** (subscribe model, auth message, ping/pong). They are different endpoints with different auth — don't conflate them.
+**Key distinction:** Broker *events* come over **SSE** (simple HTTP, replayable with `since` or `since_ulid`/`until_ulid` on v1 and `since_id` — a ULID — on v2; the v1 integer `since_id`/`until_id` are deprecated, select partners only, sunset 2027-02-15). Market *data* comes over **WebSocket** (subscribe model, auth message, ping/pong). They are different endpoints with different auth — don't conflate them.
 
 ---
 
@@ -119,7 +123,7 @@ These apply everywhere and are the source of most subtle bugs:
 When helping someone start from zero, walk them through this order:
 
 1. **Pick sandbox URLs** via an `ENV` switch.
-2. **Authenticate** with Basic (Broker) — verify with `GET /v1/accounts` (list).
+2. **Authenticate** with a client-credentials Bearer token (Broker) — verify with `GET /v1/accounts` (list).
 3. **Create an account** with full KYC payload → `alpaca-broker-account-onboarding`.
 4. **Wait for `ACTIVE`** status (via SSE account-status events or polling) before any money/trade op.
 5. **Fund it** (sandbox lets you simulate deposits) → `alpaca-broker-funding-transfers`.
@@ -149,7 +153,7 @@ When helping someone start from zero, walk them through this order:
 ## 8. Integration guidance (applies regardless of language)
 
 1. **One base-URL switch, environment-driven.** Never hardcode prod URLs in a code branch.
-2. **Build auth once.** Cache the Basic token / header set at client construction.
+2. **Hold auth behind one accessor.** Cache the Bearer token with its expiry and refresh it there, so no call site ever handles credentials.
 3. **Treat every write as async.** Model the state machine; act on terminal states, not on the `2xx`.
 4. **Persist Alpaca's IDs.** Store `account_id`, `order_id`, `journal_id`, `transfer_id` on your local records — they are your only correlation key for events and reconciliation.
 5. **Decimals, not floats**, for anything monetary. Parse the string fields into a decimal type.

--- a/skills/broker-api/journals/SKILL.md
+++ b/skills/broker-api/journals/SKILL.md
@@ -7,7 +7,7 @@ description: Move cash (JNLC) and securities (JNLS) BETWEEN accounts inside your
 
 Journals move value **between two accounts within your own Alpaca omnibus** — typically between a pre-funded firm/sweep account and a user account. They are the engine behind "instant funding," cashback, and share rewards. They never touch the outside banking world (that's `alpaca-broker-funding-transfers`).
 
-> Read `alpaca-broker-integration` first. Broker API + HTTP Basic auth.
+> Read `alpaca-broker-integration` first for base URLs and auth (client-credentials Bearer token; legacy Basic still works).
 
 ## Reference
 - Guide: `https://docs.alpaca.markets/docs/funding-via-journals`

--- a/skills/broker-api/market-data/SKILL.md
+++ b/skills/broker-api/market-data/SKILL.md
@@ -21,7 +21,7 @@ Real-time and historical US equity data. Unlike the Broker endpoints, market dat
 | Market data WebSocket | `wss://stream.data.alpaca.markets/{version}/{feed}` |
 | Assets / clock / calendar | `https://api.alpaca.markets` (Trading API) — paper: `paper-api.alpaca.markets` |
 
-**Auth:** headers `APCA-API-KEY-ID` / `APCA-API-SECRET-KEY` (Broker partners may use Broker Basic auth in broker context).
+**Auth:** Broker partners authenticate with a **client-credentials access token** (`POST https://authx.alpaca.markets/v1/oauth2/token` — flow in `alpaca-broker-integration`): send `Authorization: Bearer <token>` on REST and on the WS handshake, or authenticate over WS with `{"action":"auth","key":"access_token","secret":"<token>"}` (the literal string `access_token` is the key). Tokens are valid **15 minutes** — cache and refresh one, don't mint per call. Key/secret (`APCA-API-*` headers, or `{"action":"auth","key":"…","secret":"…"}` on WS) is the Trading API path and the documented **legacy** Broker path.
 
 ## 1. REST endpoints
 

--- a/skills/broker-api/money-precision/SKILL.md
+++ b/skills/broker-api/money-precision/SKILL.md
@@ -7,7 +7,7 @@ description: Handle money and numeric precision correctly with the Alpaca API â€
 
 Financial bugs are silent and expensive. Alpaca's wire format and the realities of decimal arithmetic create a few specific traps. This skill is short, opinionated, and language-agnostic.
 
-> Read `alpaca-broker-integration` first.
+> Read `alpaca-broker-integration` first for base URLs and auth (client-credentials Bearer token; legacy Basic still works).
 
 ## 1. Numbers come as strings â€” keep them that way
 

--- a/skills/broker-api/reconciliation-idempotency/SKILL.md
+++ b/skills/broker-api/reconciliation-idempotency/SKILL.md
@@ -7,7 +7,7 @@ description: Keep local state correct against the Alpaca Broker API — idempote
 
 This is the skill that separates a demo from production. Alpaca is an **asynchronous, eventually-consistent** system: writes settle later, events can be missed or replayed, some rails emit no events at all, and "executed" can still be reversed. Your job is to make your local database a faithful, self-healing mirror of Alpaca's state.
 
-> Read `alpaca-broker-integration`, `alpaca-broker-sse-events`, and the relevant domain skills first. This skill is the architecture that ties them together.
+> Read `alpaca-broker-integration` first for base URLs and auth (client-credentials Bearer token; legacy Basic still works), then `alpaca-broker-sse-events` and the relevant domain skills. This skill is the architecture that ties them together.
 
 ## The core principle
 

--- a/skills/broker-api/sse-events/SKILL.md
+++ b/skills/broker-api/sse-events/SKILL.md
@@ -7,7 +7,7 @@ description: Consume Alpaca Broker API real-time event streams over Server-Sent 
 
 Alpaca pushes brokerage lifecycle events over **Server-Sent Events**: a long-lived HTTP GET that streams `text/event-stream`. This is *not* the market-data WebSocket (`alpaca-broker-market-data`) — different transport, different auth, different reliability model.
 
-> Read `alpaca-broker-integration` first. SSE uses the **Broker API host + HTTP Basic auth** (same credential as Broker REST).
+> Read `alpaca-broker-integration` first for base URLs and auth (client-credentials Bearer token; legacy Basic still works).
 
 ## Reference
 - Guide: `https://docs.alpaca.markets/docs/sse-events`
@@ -40,9 +40,11 @@ SSE is plain HTTP. You don't need a special client: open a GET, keep the connect
 ```
 GET /v2/events/journals/status?since_id=<last-ulid-you-saw> HTTP/1.1
 Host: broker-api.alpaca.markets
-Authorization: Basic <base64(key:secret)>
+Authorization: Bearer <access-token>
 Accept: text/event-stream
 ```
+
+`Authorization: Basic <base64(key:secret)>` also works. Nothing documents whether an open stream survives token expiry, so treat a mid-stream `401` as just another drop and reconnect with your cursor.
 
 Read the response stream and parse `data: {…}` frames as they arrive. In most languages an off-the-shelf EventSource/SSE client works — **just make sure it lets you set the `Authorization` header** on the initial request (the browser `EventSource` API famously does *not*; use a server-side SSE library instead).
 

--- a/skills/broker-api/trading-orders/SKILL.md
+++ b/skills/broker-api/trading-orders/SKILL.md
@@ -7,7 +7,7 @@ description: Place and manage orders on behalf of accounts via the Alpaca Broker
 
 Place, modify, cancel, and track orders for an end-user account, and read positions & buying power. The defining feature of Broker API trading: **`account_id` is in the path** — you act *for* a user account, not your own.
 
-> Read `alpaca-broker-integration` first. Broker API + HTTP Basic auth. (The standalone Trading API uses `/v2/orders` with no account in the path; everything else here transfers.)
+> Read `alpaca-broker-integration` first for base URLs and auth (client-credentials Bearer token; legacy Basic still works). (The standalone Trading API uses `/v2/orders` with no account in the path; everything else here transfers.)
 
 ## Reference
 - Guides: `https://docs.alpaca.markets/docs/orders-at-alpaca`, `https://docs.alpaca.markets/docs/fractional-trading`


### PR DESCRIPTION
## Summary
- Lead Broker API auth with the client-credentials flow (`authx.alpaca.markets`, 15-minute Bearer tokens, cache-and-refresh); keep Basic and `APCA-API-*` headers as the documented legacy path and the only Trading API path
- Update the market-data auth line and WebSocket auth message for Broker access tokens, and the SSE connection example
- Point every broker skill's header at the integration skill for auth

Stacked on #10. Source: https://docs.alpaca.markets/us/docs/authentication

## Type of change
- [ ] New skill
- [x] Improvement to existing skill
- [ ] Bug fix
- [ ] Documentation / repo infrastructure

## Checklist
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] Skill lives under `skills/trading-api/` or `skills/broker-api/`
- [x] Skill `name` follows `alpaca-<product-scope>-<skill-name>` (`trading` or `broker`)
- [x] `SKILL.md` has `name` + `description` frontmatter
- [x] No API keys or secrets committed
- [ ] Disclosure language included for trading-related outputs (if applicable)
- [ ] Updated [README.md](../README.md) skills table (if adding or renaming a skill)

## Test plan
- [x] `python3 scripts/validate_skills.py` passes locally
- [ ] CI `skill-check` workflow passes
